### PR TITLE
Allow /0 function to fetch token at runtime

### DIFF
--- a/lib/coxir.ex
+++ b/lib/coxir.ex
@@ -40,7 +40,12 @@ defmodule Coxir do
     token = Application.get_env(:coxir, :token)
     cond do
       is_bitstring(token) -> token
-      is_function(token, 0) -> token.()
+      {mod, fun, arg} = token ->
+        if  is_atom(mod)
+        and is_atom(fun)
+        and is_list(arg) do 
+            apply(mod, fun, arg)
+          end
       is_nil(token) -> raise "Please provide a token."
     end
   end

--- a/lib/coxir.ex
+++ b/lib/coxir.ex
@@ -47,8 +47,8 @@ defmodule Coxir do
     |> case do
       nil ->
         raise "Please provide a token."
-      {module, function} ->
-        apply(module, function, [])
+      function when is_function(function) ->
+        function.()
       token ->
         token
     end

--- a/lib/coxir.ex
+++ b/lib/coxir.ex
@@ -36,23 +36,23 @@ defmodule Coxir do
     Supervisor.start_link(children, options)
   end
 
-  def token do
-    token = Application.get_env(:coxir, :token)
-    cond do
-      is_bitstring(token) -> token
-      {mod, fun, arg} = token ->
-        if  is_atom(mod)
-        and is_atom(fun)
-        and is_list(arg) do 
-            apply(mod, fun, arg)
-          end
-      is_nil(token) -> raise "Please provide a token."
-    end
-  end
-
   @doc false
   def child_spec(arg),
     do: super(arg)
+
+  @doc false
+  def token do
+    :coxir
+    |> Application.get_env(:token)
+    |> case do
+      nil ->
+        raise "Please provide a token."
+      {module, function} ->
+        apply(module, function, [])
+      token ->
+        token
+    end
+  end
 
   defmacro __using__(_opts) do
     quote do

--- a/lib/coxir.ex
+++ b/lib/coxir.ex
@@ -36,6 +36,15 @@ defmodule Coxir do
     Supervisor.start_link(children, options)
   end
 
+  def token do
+    token = Application.get_env(:coxir, :token)
+    cond do
+      is_bitstring(token) -> token
+      is_function(token, 0) -> token.()
+      is_nil(token) -> raise "Please provide a token."
+    end
+  end
+
   @doc false
   def child_spec(arg),
     do: super(arg)

--- a/lib/coxir/api/base.ex
+++ b/lib/coxir/api/base.ex
@@ -21,7 +21,7 @@ defmodule Coxir.API.Base do
   end
 
   def process_request_headers(headers) do
-    token = Application.get_env(:coxir, :token)
+    token = Coxir.token
     [
       {"User-Agent", "#{@library} (#{@website}, #{@version})"},
       {"Authorization", "Bot " <> token},

--- a/lib/coxir/api/base.ex
+++ b/lib/coxir/api/base.ex
@@ -21,7 +21,7 @@ defmodule Coxir.API.Base do
   end
 
   def process_request_headers(headers) do
-    token = Coxir.token
+    token = Coxir.token()
     [
       {"User-Agent", "#{@library} (#{@website}, #{@version})"},
       {"Authorization", "Bot " <> token},

--- a/lib/coxir/gateway.ex
+++ b/lib/coxir/gateway.ex
@@ -11,8 +11,7 @@ defmodule Coxir.Gateway do
 
   @doc false
   def start_link do
-    token = Application.get_env(:coxir, :token)
-    if !token, do: raise "Please provide a token."
+    token = Coxir.token
 
     %{url: gateway, shards: shards} = API.request(:get, "gateway/bot")
 

--- a/lib/coxir/gateway.ex
+++ b/lib/coxir/gateway.ex
@@ -11,7 +11,7 @@ defmodule Coxir.Gateway do
 
   @doc false
   def start_link do
-    token = Coxir.token
+    token = Coxir.token()
 
     %{url: gateway, shards: shards} = API.request(:get, "gateway/bot")
 


### PR DESCRIPTION
Fetching tokens from environment vars and/or secret stores is more secure than sticking it in a config file. Allow users to fetch tokens at runtime by providing a 0 arity function instead of a bitstring.