### PR TITLE
Added several shortcuts for edit parameters

### DIFF
--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -10,6 +10,8 @@ defmodule Coxir.Struct.Channel do
   """
   @type channel :: String.t | map
 
+  require Logger
+
   use Coxir.Struct
 
   alias Coxir.Struct.{User, Member, Overwrite, Message}
@@ -158,6 +160,146 @@ defmodule Coxir.Struct.Channel do
 
   def bulk_delete_messages(channel, messages) do
     API.request(:post, "channels/#{channel}/messages/bulk-delete", %{messages: messages})
+  end
+
+  @doc """
+  Modifies the name of a given channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+  """
+  @spec set_name(channel, String.t) :: map
+
+  def set_name(%{id: id}, name),
+    do: set_name(id, name)
+
+  def set_name(channel, name) do
+    edit(channel, %{name: name})
+  end
+
+  @doc """
+  Modifies the topic of a given channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+  """
+  @spec set_topic(channel, String.t) :: map
+
+  def set_topic(%{id: id}, topic),
+    do: set_topic(id, topic)
+
+  def set_topic(channel, topic) do
+    edit(channel, %{topic: topic})
+  end
+
+  @doc """
+  Enables the NSFW status of a given channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+  """
+  @spec enable_nsfw(channel) :: map
+
+  def enable_nsfw(%{id: id}),
+    do: enable_nsfw(id)
+
+  def enable_nsfw(channel) do
+    edit(channel, %{nsfw: true})
+  end
+
+  @doc """
+  Disables the NSFW status of a given channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+  """
+  @spec disable_nsfw(channel) :: map
+
+  def disable_nsfw(%{id: id}),
+    do: disable_nsfw(id)
+
+  def disable_nsfw(channel) do
+    edit(channel, %{nsfw: false})
+  end
+
+  @doc """
+  Modifies the position of a given channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+  """
+  @spec set_position(channel, Integer.t) :: map
+
+  def set_position(%{id: id}, position),
+    do: set_position(id, position)
+
+  def set_position(channel, position) do
+    edit(channel, %{position: position})
+  end
+
+  @doc """
+  Modifies the bitrate of a given voice channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+  """
+  @spec set_bitrate(channel, Integer.t) :: map
+
+  def set_bitrate(%{id: id}, bitrate),
+    do: set_bitrate(id, bitrate)
+
+  def set_bitrate(channel, bitrate) do
+    if bitrate != 128000 and bitrate < 8000 and bitrate > 96000 do
+      Logger.error fn ->
+        "\b[Coxir] The bitrate of the voice channel should be between 8000 and 96000 (128000 for VIP servers)."
+      end
+    end
+    edit(channel, %{bitrate: bitrate})
+  end
+
+  @doc """
+  Modifies the user limit of a given voice channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+  """
+  @spec set_user_limit(channel, Integer.t) :: map
+
+  def set_user_limit(%{id: id}, limit),
+    do: set_user_limit(id, limit)
+
+  def set_user_limit(channel, limit) do
+    edit(channel, %{user_limit: limit})
+  end
+
+  @doc """
+  Modifies the permissions of a given channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+  """
+  @spec set_permissions(channel, Enum.t) :: map
+
+  def set_permissions(%{id: id}, permission_overwrites),
+    do: set_permissions(id, permission_overwrites)
+
+  def set_permissions(channel, permission_overwrites) do
+    edit(channel, %{permission_overwrites: permission_overwrites})
+  end
+
+  @doc """
+  Modifies the parent id of a given channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+  """
+  @spec set_parent(channel, String.t) :: map
+
+  def set_parent(%{id: id}, parent),
+    do: set_parent(id, parent)
+
+  def set_parent(channel, parent) do
+    edit(channel, %{parent_id: parent})
   end
 
   @doc """

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -198,12 +198,8 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_name(channel, String.t) :: map
 
-  def set_name(%{id: id}, name),
-    do: set_name(id, name)
-
-  def set_name(channel, name) do
-    edit(channel, %{name: name})
-  end
+  def set_name(channel, name),
+    do: edit(channel, name: name)
 
   @doc """
   Modifies the topic of a given channel.
@@ -213,12 +209,8 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_topic(channel, String.t) :: map
 
-  def set_topic(%{id: id}, topic),
-    do: set_topic(id, topic)
-
-  def set_topic(channel, topic) do
-    edit(channel, %{topic: topic})
-  end
+  def set_topic(channel, topic),
+    do: edit(channel, topic: topic)
 
   @doc """
   Enables the NSFW status of a given channel.
@@ -258,12 +250,8 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_position(channel, Integer.t) :: map
 
-  def set_position(%{id: id}, position),
-    do: set_position(id, position)
-
-  def set_position(channel, position) do
-    edit(channel, %{position: position})
-  end
+  def set_position(channel, position),
+    do: edit(channel, position: position)
 
   @doc """
   Modifies the bitrate of a given voice channel.
@@ -273,12 +261,8 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_bitrate(channel, Integer.t) :: map
 
-  def set_bitrate(%{id: id}, bitrate),
-    do: set_bitrate(id, bitrate)
-
-  def set_bitrate(channel, bitrate) do
-    edit(channel, %{bitrate: bitrate})
-  end
+  def set_bitrate(channel, bitrate),
+    do: edit(channel, bitrate: bitrate)
 
   @doc """
   Modifies the user limit of a given voice channel.
@@ -288,12 +272,8 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_user_limit(channel, Integer.t) :: map
 
-  def set_user_limit(%{id: id}, limit),
-    do: set_user_limit(id, limit)
-
-  def set_user_limit(channel, limit) do
-    edit(channel, %{user_limit: limit})
-  end
+  def set_user_limit(channel, limit),
+    do: edit(channel, user_limit: limit)
 
   @doc """
   Modifies the permissions of a given channel.
@@ -303,12 +283,8 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_permissions(channel, Enum.t) :: map
 
-  def set_permissions(%{id: id}, permission_overwrites),
-    do: set_permissions(id, permission_overwrites)
-
-  def set_permissions(channel, permission_overwrites) do
-    edit(channel, %{permission_overwrites: permission_overwrites})
-  end
+  def set_permissions(channel, permission_overwrites),
+    do: edit(channel, permission_overwrites: permission_overwrites)
 
   @doc """
   Modifies the parent id of a given channel.
@@ -318,12 +294,8 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_parent(channel, String.t) :: map
 
-  def set_parent(%{id: id}, parent),
-    do: set_parent(id, parent)
-
-  def set_parent(channel, parent) do
-    edit(channel, %{parent_id: parent})
-  end
+  def set_parent(channel, parent),
+    do: edit(channel, parent_id: parent)
 
   @doc """
   Deletes a given channel.

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -213,27 +213,15 @@ defmodule Coxir.Struct.Channel do
     do: edit(channel, topic: topic)
 
   @doc """
-  Enables the NSFW status of a given channel.
+  Modifies the NSFW status of a given channel.
 
   Returns a channel object upon success
   or a map containing error information.
   """
-  @spec enable_nsfw(channel) :: map
+  @spec enable_nsfw(channel, Boolean.t) :: map
 
-  def enable_nsfw(channel) do
-    edit(channel, nsfw: true)
-  end
-
-  @doc """
-  Disables the NSFW status of a given channel.
-
-  Returns a channel object upon success
-  or a map containing error information.
-  """
-  @spec disable_nsfw(channel) :: map
-
-  def disable_nsfw(channel) do
-    edit(channel, nsfw: false)
+  def set_nsfw(channel, state) do
+    edit(channel, nsfw: state)
   end
 
   @doc """

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -163,6 +163,36 @@ defmodule Coxir.Struct.Channel do
   end
 
   @doc """
+  Modifies a given channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+
+  #### Params
+  Must be an enumerable with the fields listed below.
+  - `name` - channel name (2-100 characters)
+  - `topic` - channel topic (up to 1024 characters)
+  - `nsfw` - whether the channel is NSFW
+  - `position` - the position in the left-hand listing
+  - `bitrate` - the bitrate in bits of the voice channel
+  - `user_limit` - the user limit of the voice channel
+  - `permission_overwrites` - channel or category-specific permissions
+  - `parent_id` - id of the new parent category
+
+  Refer to [this](https://discordapp.com/developers/docs/resources/channel#modify-channel)
+  for a broader explanation on the fields and their defaults.
+  """
+  @spec edit(channel, Enum.t) :: map
+
+  def edit(%{id: id}, params),
+    do: edit(id, params)
+
+  def edit(channel, params) do
+    API.request(:patch, "channels/#{channel}", params)
+    |> pretty
+  end
+
+  @doc """
   Modifies the name of a given channel.
 
   Returns a channel object upon success
@@ -300,36 +330,6 @@ defmodule Coxir.Struct.Channel do
 
   def set_parent(channel, parent) do
     edit(channel, %{parent_id: parent})
-  end
-
-  @doc """
-  Modifies a given channel.
-
-  Returns a channel object upon success
-  or a map containing error information.
-
-  #### Params
-  Must be an enumerable with the fields listed below.
-  - `name` - channel name (2-100 characters)
-  - `topic` - channel topic (up to 1024 characters)
-  - `nsfw` - whether the channel is NSFW
-  - `position` - the position in the left-hand listing
-  - `bitrate` - the bitrate in bits of the voice channel
-  - `user_limit` - the user limit of the voice channel
-  - `permission_overwrites` - channel or category-specific permissions
-  - `parent_id` - id of the new parent category
-
-  Refer to [this](https://discordapp.com/developers/docs/resources/channel#modify-channel)
-  for a broader explanation on the fields and their defaults.
-  """
-  @spec edit(channel, Enum.t) :: map
-
-  def edit(%{id: id}, params),
-    do: edit(id, params)
-
-  def edit(channel, params) do
-    API.request(:patch, "channels/#{channel}", params)
-    |> pretty
   end
 
   @doc """

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -230,7 +230,7 @@ defmodule Coxir.Struct.Channel do
     do: enable_nsfw(id)
 
   def enable_nsfw(channel) do
-    edit(channel, %{nsfw: true})
+    edit(channel, nsfw: true)
   end
 
   @doc """
@@ -245,7 +245,7 @@ defmodule Coxir.Struct.Channel do
     do: disable_nsfw(id)
 
   def disable_nsfw(channel) do
-    edit(channel, %{nsfw: false})
+    edit(channel, nsfw: false)
   end
 
   @doc """

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -213,17 +213,6 @@ defmodule Coxir.Struct.Channel do
     do: edit(channel, topic: topic)
 
   @doc """
-  Modifies the NSFW status of a given channel.
-
-  Returns a channel object upon success
-  or a map containing error information.
-  """
-  @spec set_nsfw(channel, boolean) :: map
-
-  def set_nsfw(channel, bool),
-    do: edit(channel, nsfw: bool)
-
-  @doc """
   Modifies the position of a given channel.
 
   Returns a channel object upon success
@@ -233,6 +222,28 @@ defmodule Coxir.Struct.Channel do
 
   def set_position(channel, position),
     do: edit(channel, position: position)
+
+  @doc """
+  Modifies the parent category of a given channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+  """
+  @spec set_parent(channel, String.t) :: map
+
+  def set_parent(channel, parent),
+    do: edit(channel, parent_id: parent)
+
+  @doc """
+  Modifies the NSFW flag of a given channel.
+
+  Returns a channel object upon success
+  or a map containing error information.
+  """
+  @spec set_nsfw(channel, boolean) :: map
+
+  def set_nsfw(channel, bool),
+    do: edit(channel, nsfw: bool)
 
   @doc """
   Modifies the bitrate of a given voice channel.
@@ -255,28 +266,6 @@ defmodule Coxir.Struct.Channel do
 
   def set_user_limit(channel, limit),
     do: edit(channel, user_limit: limit)
-
-  @doc """
-  Modifies the permissions of a given channel.
-
-  Returns a channel object upon success
-  or a map containing error information.
-  """
-  @spec set_permissions(channel, Enum.t) :: map
-
-  def set_permissions(channel, permissions),
-    do: edit(channel, permission_overwrites: permissions)
-
-  @doc """
-  Modifies the parent id of a given channel.
-
-  Returns a channel object upon success
-  or a map containing error information.
-  """
-  @spec set_parent(channel, String.t) :: map
-
-  def set_parent(channel, parent),
-    do: edit(channel, parent_id: parent)
 
   @doc """
   Deletes a given channel.

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -191,7 +191,7 @@ defmodule Coxir.Struct.Channel do
   end
 
   @doc """
-  Modifies the name of a given channel.
+  Changes the name of a given channel.
 
   Returns a channel object upon success
   or a map containing error information.
@@ -202,7 +202,7 @@ defmodule Coxir.Struct.Channel do
     do: edit(channel, name: name)
 
   @doc """
-  Modifies the topic of a given channel.
+  Changes the topic of a given channel.
 
   Returns a channel object upon success
   or a map containing error information.
@@ -213,7 +213,7 @@ defmodule Coxir.Struct.Channel do
     do: edit(channel, topic: topic)
 
   @doc """
-  Modifies the position of a given channel.
+  Changes the position of a given channel.
 
   Returns a channel object upon success
   or a map containing error information.
@@ -224,7 +224,7 @@ defmodule Coxir.Struct.Channel do
     do: edit(channel, position: position)
 
   @doc """
-  Modifies the parent category of a given channel.
+  Changes the parent category of a given channel.
 
   Returns a channel object upon success
   or a map containing error information.
@@ -235,7 +235,7 @@ defmodule Coxir.Struct.Channel do
     do: edit(channel, parent_id: parent)
 
   @doc """
-  Modifies the NSFW flag of a given channel.
+  Changes the NSFW flag of a given channel.
 
   Returns a channel object upon success
   or a map containing error information.
@@ -246,7 +246,7 @@ defmodule Coxir.Struct.Channel do
     do: edit(channel, nsfw: bool)
 
   @doc """
-  Modifies the bitrate of a given voice channel.
+  Changes the bitrate of a given voice channel.
 
   Returns a channel object upon success
   or a map containing error information.
@@ -257,7 +257,7 @@ defmodule Coxir.Struct.Channel do
     do: edit(channel, bitrate: bitrate)
 
   @doc """
-  Modifies the user limit of a given voice channel.
+  Changes the user limit of a given voice channel.
 
   Returns a channel object upon success
   or a map containing error information.

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -10,8 +10,6 @@ defmodule Coxir.Struct.Channel do
   """
   @type channel :: String.t | map
 
-  require Logger
-
   use Coxir.Struct
 
   alias Coxir.Struct.{User, Member, Overwrite, Message}
@@ -279,11 +277,6 @@ defmodule Coxir.Struct.Channel do
     do: set_bitrate(id, bitrate)
 
   def set_bitrate(channel, bitrate) do
-    if bitrate != 128000 and bitrate < 8000 and bitrate > 96000 do
-      Logger.error fn ->
-        "\b[Coxir] The bitrate of the voice channel should be between 8000 and 96000 (128000 for VIP servers)."
-      end
-    end
     edit(channel, %{bitrate: bitrate})
   end
 

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -198,6 +198,9 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_name(channel, String.t) :: map
 
+  def set_name(%{id: id}, name),
+    do: set_name(id, name)
+
   def set_name(channel, name),
     do: edit(channel, name: name)
 
@@ -208,6 +211,9 @@ defmodule Coxir.Struct.Channel do
   or a map containing error information.
   """
   @spec set_topic(channel, String.t) :: map
+
+  def set_topic(%{id: id}, topic),
+    do: set_topic(id, topic)
 
   def set_topic(channel, topic),
     do: edit(channel, topic: topic)
@@ -250,6 +256,9 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_position(channel, Integer.t) :: map
 
+  def set_position(%{id: id}, position),
+    do: set_position(id, position)
+
   def set_position(channel, position),
     do: edit(channel, position: position)
 
@@ -260,6 +269,9 @@ defmodule Coxir.Struct.Channel do
   or a map containing error information.
   """
   @spec set_bitrate(channel, Integer.t) :: map
+
+  def set_bitrate(%{id: id}, bitrate),
+    do: set_bitrate(id, bitrate)
 
   def set_bitrate(channel, bitrate),
     do: edit(channel, bitrate: bitrate)
@@ -272,6 +284,9 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_user_limit(channel, Integer.t) :: map
 
+  def set_user_limit(%{id: id}, limit),
+    do: set_user_limit(id, limit)
+
   def set_user_limit(channel, limit),
     do: edit(channel, user_limit: limit)
 
@@ -283,8 +298,11 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_permissions(channel, Enum.t) :: map
 
-  def set_permissions(channel, permission_overwrites),
-    do: edit(channel, permission_overwrites: permission_overwrites)
+  def set_permissions(%{id: id}, permissions),
+    do: set_permissions(id, permissions)
+
+  def set_permissions(channel, permissions),
+    do: edit(channel, permission_overwrites: permissions)
 
   @doc """
   Modifies the parent id of a given channel.
@@ -293,6 +311,9 @@ defmodule Coxir.Struct.Channel do
   or a map containing error information.
   """
   @spec set_parent(channel, String.t) :: map
+
+  def set_parent(%{id: id}, parent),
+    do: set_parent(id, parent)
 
   def set_parent(channel, parent),
     do: edit(channel, parent_id: parent)

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -218,7 +218,7 @@ defmodule Coxir.Struct.Channel do
   Returns a channel object upon success
   or a map containing error information.
   """
-  @spec enable_nsfw(channel, Boolean.t) :: map
+  @spec set_nsfw(channel, Boolean.t) :: map
 
   def set_nsfw(channel, state),
     do: edit(channel, nsfw: state)

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -220,8 +220,8 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_nsfw(channel, Boolean.t) :: map
 
-  def set_nsfw(channel, state),
-    do: edit(channel, nsfw: state)
+  def set_nsfw(channel, bool),
+    do: edit(channel, nsfw: bool)
 
   @doc """
   Modifies the position of a given channel.

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -198,9 +198,6 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_name(channel, String.t) :: map
 
-  def set_name(%{id: id}, name),
-    do: set_name(id, name)
-
   def set_name(channel, name),
     do: edit(channel, name: name)
 
@@ -212,9 +209,6 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_topic(channel, String.t) :: map
 
-  def set_topic(%{id: id}, topic),
-    do: set_topic(id, topic)
-
   def set_topic(channel, topic),
     do: edit(channel, topic: topic)
 
@@ -225,9 +219,6 @@ defmodule Coxir.Struct.Channel do
   or a map containing error information.
   """
   @spec enable_nsfw(channel) :: map
-
-  def enable_nsfw(%{id: id}),
-    do: enable_nsfw(id)
 
   def enable_nsfw(channel) do
     edit(channel, nsfw: true)
@@ -241,9 +232,6 @@ defmodule Coxir.Struct.Channel do
   """
   @spec disable_nsfw(channel) :: map
 
-  def disable_nsfw(%{id: id}),
-    do: disable_nsfw(id)
-
   def disable_nsfw(channel) do
     edit(channel, nsfw: false)
   end
@@ -256,9 +244,6 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_position(channel, Integer.t) :: map
 
-  def set_position(%{id: id}, position),
-    do: set_position(id, position)
-
   def set_position(channel, position),
     do: edit(channel, position: position)
 
@@ -269,9 +254,6 @@ defmodule Coxir.Struct.Channel do
   or a map containing error information.
   """
   @spec set_bitrate(channel, Integer.t) :: map
-
-  def set_bitrate(%{id: id}, bitrate),
-    do: set_bitrate(id, bitrate)
 
   def set_bitrate(channel, bitrate),
     do: edit(channel, bitrate: bitrate)
@@ -284,9 +266,6 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_user_limit(channel, Integer.t) :: map
 
-  def set_user_limit(%{id: id}, limit),
-    do: set_user_limit(id, limit)
-
   def set_user_limit(channel, limit),
     do: edit(channel, user_limit: limit)
 
@@ -298,9 +277,6 @@ defmodule Coxir.Struct.Channel do
   """
   @spec set_permissions(channel, Enum.t) :: map
 
-  def set_permissions(%{id: id}, permissions),
-    do: set_permissions(id, permissions)
-
   def set_permissions(channel, permissions),
     do: edit(channel, permission_overwrites: permissions)
 
@@ -311,9 +287,6 @@ defmodule Coxir.Struct.Channel do
   or a map containing error information.
   """
   @spec set_parent(channel, String.t) :: map
-
-  def set_parent(%{id: id}, parent),
-    do: set_parent(id, parent)
 
   def set_parent(channel, parent),
     do: edit(channel, parent_id: parent)

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -220,9 +220,8 @@ defmodule Coxir.Struct.Channel do
   """
   @spec enable_nsfw(channel, Boolean.t) :: map
 
-  def set_nsfw(channel, state) do
-    edit(channel, nsfw: state)
-  end
+  def set_nsfw(channel, state),
+    do: edit(channel, nsfw: state)
 
   @doc """
   Modifies the position of a given channel.

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -218,7 +218,7 @@ defmodule Coxir.Struct.Channel do
   Returns a channel object upon success
   or a map containing error information.
   """
-  @spec set_nsfw(channel, Boolean.t) :: map
+  @spec set_nsfw(channel, boolean) :: map
 
   def set_nsfw(channel, bool),
     do: edit(channel, nsfw: bool)

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -72,10 +72,6 @@ defmodule Coxir.Struct.Guild do
   - `afk_timeout` - voice AFK timeout in seconds
   - `afk_channel_id` - voice AFK channel
   - `system_channel_id` - channel to which system messages are sent
-  - `owner_id` - user id to transfer guild ownership to (must be owner)
-  - `verification_level` - verification level
-  - `default_message_notifications` - default message notification level
-  - `explicit_content_filter` - explicit content filter level
 
   Refer to [this](https://discordapp.com/developers/docs/resources/guild#modify-guild)
   for a broader explanation on the fields and their defaults.
@@ -102,17 +98,6 @@ defmodule Coxir.Struct.Guild do
     do: edit(guild, name: name)
 
   @doc """
-  Modifies the region of a given guild.
-
-  Returns a guild object upon success
-  or a map containing error information.
-  """
-  @spec set_region(guild, String.t) :: map
-
-  def set_region(guild, region),
-    do: edit(guild, region: region)
-
-  @doc """
   Modifies the icon of a given guild.
 
   Returns a guild object upon success
@@ -124,7 +109,18 @@ defmodule Coxir.Struct.Guild do
     do: edit(guild, icon: icon)
 
   @doc """
-  Modifies the splash of a given guild (VIP only).
+  Modifies the region of a given guild.
+
+  Returns a guild object upon success
+  or a map containing error information.
+  """
+  @spec set_region(guild, String.t) :: map
+
+  def set_region(guild, region),
+    do: edit(guild, region: region)
+
+  @doc """
+  Modifies the splash of a given guild.
 
   Returns a guild object upon success
   or a map containing error information.
@@ -135,7 +131,7 @@ defmodule Coxir.Struct.Guild do
     do: edit(guild, splash: splash)
 
   @doc """
-  Modifies the afk timeout of a given guild.
+  Modifies the voice AFK timeout of a given guild.
 
   Returns a guild object upon success
   or a map containing error information.
@@ -146,7 +142,7 @@ defmodule Coxir.Struct.Guild do
     do: edit(guild, afk_timeout: timeout)
 
   @doc """
-  Modifies the id for afk channel of a given guild.
+  Modifies the voice AFK channel of a given guild.
 
   Returns a guild object upon success
   or a map containing error information.
@@ -157,7 +153,7 @@ defmodule Coxir.Struct.Guild do
     do: edit(guild, afk_channel_id: channel)
 
   @doc """
-  Modifies the id of the channel to which system messages are sent of a given guild.
+  Modifies the channel to which system messages are sent on a given guild.
 
   Returns a guild object upon success
   or a map containing error information.
@@ -166,39 +162,6 @@ defmodule Coxir.Struct.Guild do
 
   def set_system_channel(guild, channel),
     do: edit(guild, system_channel_id: channel)
-
-  @doc """
-  Transfers the ownership of a given guild.
-
-  Returns a guild object upon success
-  or a map containing error information.
-  """
-  @spec transfer_ownership(guild, String.t) :: map
-
-  def transfer_ownership(guild, user),
-    do: edit(guild, owner_id: user)
-
-  @doc """
-  Modifies the verification level of a given guild.
-
-  Returns a guild object upon success
-  or a map containing error information.
-  """
-  @spec set_verification_level(guild, Integer.t) :: map
-
-  def set_verification_level(guild, level),
-    do: edit(guild, verification_level: level)
-
-  @doc """
-  Modifies the explicit content filter level of a given guild.
-
-  Returns a guild object upon success
-  or a map containing error information.
-  """
-  @spec set_content_filter(guild, Integer.t) :: map
-
-  def set_content_filter(guild, level),
-    do: edit(guild, explicit_content_filter: level)
 
   @doc """
   Deletes a given guild.

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -58,6 +58,39 @@ defmodule Coxir.Struct.Guild do
   end
 
   @doc """
+  Modifies a given guild.
+
+  Returns a guild object upon success
+  or a map containing error information.
+
+  #### Params
+  Must be an enumerable with the fields listed below.
+  - `name` - guild name
+  - `region` - guild voice region
+  - `icon` - base64 encoded 128x128 jpeg image
+  - `splash` - base64 encoded 128x128 jpeg image
+  - `afk_timeout` - voice AFK timeout in seconds
+  - `afk_channel_id` - voice AFK channel
+  - `system_channel_id` - channel to which system messages are sent
+  - `owner_id` - user id to transfer guild ownership to (must be owner)
+  - `verification_level` - verification level
+  - `default_message_notifications` - default message notification level
+  - `explicit_content_filter` - explicit content filter level
+
+  Refer to [this](https://discordapp.com/developers/docs/resources/guild#modify-guild)
+  for a broader explanation on the fields and their defaults.
+  """
+  @spec edit(guild, Enum.t) :: map
+
+  def edit(%{id: id}, params),
+    do: edit(id, params)
+
+  def edit(guild, params) do
+    API.request(:patch, "guilds/#{guild}", params)
+    |> pretty
+  end
+
+  @doc """
   Modifies the name of a given guild.
 
   Returns a guild object upon success
@@ -205,39 +238,6 @@ defmodule Coxir.Struct.Guild do
 
   def set_content_filter(guild, level) do
     edit(guild, %{explicit_content_filter: level})
-  end
-
-  @doc """
-  Modifies a given guild.
-
-  Returns a guild object upon success
-  or a map containing error information.
-
-  #### Params
-  Must be an enumerable with the fields listed below.
-  - `name` - guild name
-  - `region` - guild voice region
-  - `icon` - base64 encoded 128x128 jpeg image
-  - `splash` - base64 encoded 128x128 jpeg image
-  - `afk_timeout` - voice AFK timeout in seconds
-  - `afk_channel_id` - voice AFK channel
-  - `system_channel_id` - channel to which system messages are sent
-  - `owner_id` - user id to transfer guild ownership to (must be owner)
-  - `verification_level` - verification level
-  - `default_message_notifications` - default message notification level
-  - `explicit_content_filter` - explicit content filter level
-
-  Refer to [this](https://discordapp.com/developers/docs/resources/guild#modify-guild)
-  for a broader explanation on the fields and their defaults.
-  """
-  @spec edit(guild, Enum.t) :: map
-
-  def edit(%{id: id}, params),
-    do: edit(id, params)
-
-  def edit(guild, params) do
-    API.request(:patch, "guilds/#{guild}", params)
-    |> pretty
   end
 
   @doc """

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -101,9 +101,8 @@ defmodule Coxir.Struct.Guild do
   def set_name(%{id: id}, name),
     do: set_name(id, name)
 
-  def set_name(guild, name) do
-    edit(guild, %{name: name})
-  end
+  def set_name(guild, name),
+    do: edit(guild, name: name)
 
   @doc """
   Modifies the region of a given guild.
@@ -116,9 +115,8 @@ defmodule Coxir.Struct.Guild do
   def set_region(%{id: id}, region),
     do: set_region(id, region)
 
-  def set_region(guild, region) do
-    edit(guild, %{region: region})
-  end
+  def set_region(guild, region),
+    do: edit(guild, region: region)
 
   @doc """
   Modifies the icon of a given guild.
@@ -131,9 +129,8 @@ defmodule Coxir.Struct.Guild do
   def set_icon(%{id: id}, icon),
     do: set_icon(id, icon)
 
-  def set_icon(guild, icon) do
-    edit(guild, %{region: icon})
-  end
+  def set_icon(guild, icon),
+    do: edit(guild, icon: icon)
 
   @doc """
   Modifies the splash of a given guild (VIP only).
@@ -146,9 +143,8 @@ defmodule Coxir.Struct.Guild do
   def set_splash(%{id: id}, splash),
     do: set_splash(id, splash)
 
-  def set_splash(guild, splash) do
-    edit(guild, %{splash: splash})
-  end
+  def set_splash(guild, splash),
+    do: edit(guild, splash: splash)
 
   @doc """
   Modifies the afk timeout of a given guild.
@@ -161,9 +157,8 @@ defmodule Coxir.Struct.Guild do
   def set_afk_timeout(%{id: id}, timeout),
     do: set_afk_timeout(id, timeout)
 
-  def set_afk_timeout(guild, timeout) do
-    edit(guild, %{afk_timeout: timeout})
-  end
+  def set_afk_timeout(guild, timeout),
+    do: edit(guild, afk_timeout: timeout)
 
   @doc """
   Modifies the id for afk channel of a given guild.
@@ -176,9 +171,8 @@ defmodule Coxir.Struct.Guild do
   def set_afk_channel(%{id: id}, channel_id),
     do: set_afk_channel(id, channel_id)
 
-  def set_afk_channel(guild, channel_id) do
-    edit(guild, %{afk_channel_id: channel_id})
-  end
+  def set_afk_channel(guild, channel_id),
+    do: edit(guild, afk_channel_id: channel_id)
 
   @doc """
   Modifies the id of the channel to which system messages are sent of a given guild.
@@ -191,9 +185,8 @@ defmodule Coxir.Struct.Guild do
   def set_system_channel(%{id: id}, channel_id),
     do: set_system_channel(id, channel_id)
 
-  def set_system_channel(guild, channel_id) do
-    edit(guild, %{system_channel_id: channel_id})
-  end
+  def set_system_channel(guild, channel_id),
+    do: edit(guild, system_channel_id: channel_id)
 
   @doc """
   Transfers the ownership of a given guild.
@@ -206,9 +199,8 @@ defmodule Coxir.Struct.Guild do
   def transfer_ownership(%{id: id}, user_id),
     do: transfer_ownership(id, user_id)
 
-  def transfer_ownership(guild, user_id) do
-    edit(guild, %{owner_id: user_id})
-  end
+  def transfer_ownership(guild, user_id),
+    do: edit(guild, owner_id: user_id)
 
   @doc """
   Modifies the verification level of a given guild.
@@ -221,9 +213,8 @@ defmodule Coxir.Struct.Guild do
   def set_verification_level(%{id: id}, level),
     do: set_verification_level(id, level)
 
-  def set_verification_level(guild, level) do
-    edit(guild, %{verification_level: level})
-  end
+  def set_verification_level(guild, level),
+    do: edit(guild, verification_level: level)
 
   @doc """
   Modifies the explicit content filter level of a given guild.
@@ -236,9 +227,8 @@ defmodule Coxir.Struct.Guild do
   def set_content_filter(%{id: id}, level),
     do: set_content_filter(id, level)
 
-  def set_content_filter(guild, level) do
-    edit(guild, %{explicit_content_filter: level})
-  end
+  def set_content_filter(guild, level),
+    do: edit(guild, explicit_content_filter: level)
 
   @doc """
   Deletes a given guild.

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -58,6 +58,156 @@ defmodule Coxir.Struct.Guild do
   end
 
   @doc """
+  Modifies the name of a given guild.
+
+  Returns a guild object upon success
+  or a map containing error information.
+  """
+  @spec set_name(guild, String.t) :: map
+
+  def set_name(%{id: id}, name),
+    do: set_name(id, name)
+
+  def set_name(guild, name) do
+    edit(guild, %{name: name})
+  end
+
+  @doc """
+  Modifies the region of a given guild.
+
+  Returns a guild object upon success
+  or a map containing error information.
+  """
+  @spec set_region(guild, String.t) :: map
+
+  def set_region(%{id: id}, region),
+    do: set_region(id, region)
+
+  def set_region(guild, region) do
+    edit(guild, %{region: region})
+  end
+
+  @doc """
+  Modifies the icon of a given guild.
+
+  Returns a guild object upon success
+  or a map containing error information.
+  """
+  @spec set_region(guild, String.t) :: map
+
+  def set_icon(%{id: id}, icon),
+    do: set_icon(id, icon)
+
+  def set_icon(guild, icon) do
+    edit(guild, %{region: icon})
+  end
+
+  @doc """
+  Modifies the splash of a given guild (VIP only).
+
+  Returns a guild object upon success
+  or a map containing error information.
+  """
+  @spec set_splash(guild, String.t) :: map
+
+  def set_splash(%{id: id}, splash),
+    do: set_splash(id, splash)
+
+  def set_splash(guild, splash) do
+    edit(guild, %{splash: splash})
+  end
+
+  @doc """
+  Modifies the afk timeout of a given guild.
+
+  Returns a guild object upon success
+  or a map containing error information.
+  """
+  @spec set_afk_timeout(guild, Integer.t) :: map
+
+  def set_afk_timeout(%{id: id}, timeout),
+    do: set_afk_timeout(id, timeout)
+
+  def set_afk_timeout(guild, timeout) do
+    edit(guild, %{afk_timeout: timeout})
+  end
+
+  @doc """
+  Modifies the id for afk channel of a given guild.
+
+  Returns a guild object upon success
+  or a map containing error information.
+  """
+  @spec set_afk_channel(guild, String.t) :: map
+
+  def set_afk_channel(%{id: id}, channel_id),
+    do: set_afk_channel(id, channel_id)
+
+  def set_afk_channel(guild, channel_id) do
+    edit(guild, %{afk_channel_id: channel_id})
+  end
+
+  @doc """
+  Modifies the id of the channel to which system messages are sent of a given guild.
+
+  Returns a guild object upon success
+  or a map containing error information.
+  """
+  @spec set_system_channel(guild, String.t) :: map
+
+  def set_system_channel(%{id: id}, channel_id), #Maybe Channel module should have a shortcut to this function?
+    do: set_system_channel(id, channel_id)
+
+  def set_system_channel(guild, channel_id) do
+    edit(guild, %{system_channel_id: channel_id})
+  end
+
+  @doc """
+  Transfers the ownership of a given guild.
+
+  Returns a guild object upon success
+  or a map containing error information.
+  """
+  @spec transfer(guild, String.t) :: map
+
+  def transfer(%{id: id}, user_id),
+    do: transfer(id, user_id)
+
+  def transfer(guild, user_id) do
+    edit(guild, %{owner_id: user_id})
+  end
+
+  @doc """
+  Modifies the verification level of a given guild.
+
+  Returns a guild object upon success
+  or a map containing error information.
+  """
+  @spec set_verification_level(guild, Integer.t) :: map
+
+  def set_verification_level(%{id: id}, level),
+    do: set_verification_level(id, level)
+
+  def set_verification_level(guild, level) do
+    edit(guild, %{verification_level: level})
+  end
+
+  @doc """
+  Modifies the explicit content filter level of a given guild.
+
+  Returns a guild object upon success
+  or a map containing error information.
+  """
+  @spec set_content_filter(guild, Integer.t) :: map
+
+  def set_content_filter(%{id: id}, level),
+    do: set_content_filter(id, level)
+
+  def set_content_filter(guild, level) do
+    edit(guild, %{explicit_content_filter: level})
+  end
+
+  @doc """
   Modifies a given guild.
 
   Returns a guild object upon success
@@ -72,6 +222,11 @@ defmodule Coxir.Struct.Guild do
   - `afk_timeout` - voice AFK timeout in seconds
   - `afk_channel_id` - voice AFK channel
   - `system_channel_id` - channel to which system messages are sent
+  - `owner_id` - user id to transfer guild ownership to (must be owner)
+  - `verification_level` - verification level
+  - `default_message_notifications` - default message notification level
+  - `explicit_content_filter` - explicit content filter level
+
 
   Refer to [this](https://discordapp.com/developers/docs/resources/guild#modify-guild)
   for a broader explanation on the fields and their defaults.

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -98,9 +98,6 @@ defmodule Coxir.Struct.Guild do
   """
   @spec set_name(guild, String.t) :: map
 
-  def set_name(%{id: id}, name),
-    do: set_name(id, name)
-
   def set_name(guild, name),
     do: edit(guild, name: name)
 
@@ -111,9 +108,6 @@ defmodule Coxir.Struct.Guild do
   or a map containing error information.
   """
   @spec set_region(guild, String.t) :: map
-
-  def set_region(%{id: id}, region),
-    do: set_region(id, region)
 
   def set_region(guild, region),
     do: edit(guild, region: region)
@@ -126,9 +120,6 @@ defmodule Coxir.Struct.Guild do
   """
   @spec set_region(guild, String.t) :: map
 
-  def set_icon(%{id: id}, icon),
-    do: set_icon(id, icon)
-
   def set_icon(guild, icon),
     do: edit(guild, icon: icon)
 
@@ -139,9 +130,6 @@ defmodule Coxir.Struct.Guild do
   or a map containing error information.
   """
   @spec set_splash(guild, String.t) :: map
-
-  def set_splash(%{id: id}, splash),
-    do: set_splash(id, splash)
 
   def set_splash(guild, splash),
     do: edit(guild, splash: splash)
@@ -154,9 +142,6 @@ defmodule Coxir.Struct.Guild do
   """
   @spec set_afk_timeout(guild, Integer.t) :: map
 
-  def set_afk_timeout(%{id: id}, timeout),
-    do: set_afk_timeout(id, timeout)
-
   def set_afk_timeout(guild, timeout),
     do: edit(guild, afk_timeout: timeout)
 
@@ -167,9 +152,6 @@ defmodule Coxir.Struct.Guild do
   or a map containing error information.
   """
   @spec set_afk_channel(guild, String.t) :: map
-
-  def set_afk_channel(%{id: id}, channel_id),
-    do: set_afk_channel(id, channel_id)
 
   def set_afk_channel(guild, channel_id),
     do: edit(guild, afk_channel_id: channel_id)
@@ -182,9 +164,6 @@ defmodule Coxir.Struct.Guild do
   """
   @spec set_system_channel(guild, String.t) :: map
 
-  def set_system_channel(%{id: id}, channel_id),
-    do: set_system_channel(id, channel_id)
-
   def set_system_channel(guild, channel_id),
     do: edit(guild, system_channel_id: channel_id)
 
@@ -195,9 +174,6 @@ defmodule Coxir.Struct.Guild do
   or a map containing error information.
   """
   @spec transfer_ownership(guild, String.t) :: map
-
-  def transfer_ownership(%{id: id}, user_id),
-    do: transfer_ownership(id, user_id)
 
   def transfer_ownership(guild, user_id),
     do: edit(guild, owner_id: user_id)
@@ -210,9 +186,6 @@ defmodule Coxir.Struct.Guild do
   """
   @spec set_verification_level(guild, Integer.t) :: map
 
-  def set_verification_level(%{id: id}, level),
-    do: set_verification_level(id, level)
-
   def set_verification_level(guild, level),
     do: edit(guild, verification_level: level)
 
@@ -223,9 +196,6 @@ defmodule Coxir.Struct.Guild do
   or a map containing error information.
   """
   @spec set_content_filter(guild, Integer.t) :: map
-
-  def set_content_filter(%{id: id}, level),
-    do: set_content_filter(id, level)
 
   def set_content_filter(guild, level),
     do: edit(guild, explicit_content_filter: level)

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -153,8 +153,8 @@ defmodule Coxir.Struct.Guild do
   """
   @spec set_afk_channel(guild, String.t) :: map
 
-  def set_afk_channel(guild, channel_id),
-    do: edit(guild, afk_channel_id: channel_id)
+  def set_afk_channel(guild, channel),
+    do: edit(guild, afk_channel_id: channel)
 
   @doc """
   Modifies the id of the channel to which system messages are sent of a given guild.
@@ -164,8 +164,8 @@ defmodule Coxir.Struct.Guild do
   """
   @spec set_system_channel(guild, String.t) :: map
 
-  def set_system_channel(guild, channel_id),
-    do: edit(guild, system_channel_id: channel_id)
+  def set_system_channel(guild, channel),
+    do: edit(guild, system_channel_id: channel)
 
   @doc """
   Transfers the ownership of a given guild.
@@ -175,8 +175,8 @@ defmodule Coxir.Struct.Guild do
   """
   @spec transfer_ownership(guild, String.t) :: map
 
-  def transfer_ownership(guild, user_id),
-    do: edit(guild, owner_id: user_id)
+  def transfer_ownership(guild, user),
+    do: edit(guild, owner_id: user)
 
   @doc """
   Modifies the verification level of a given guild.

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -155,7 +155,7 @@ defmodule Coxir.Struct.Guild do
   """
   @spec set_system_channel(guild, String.t) :: map
 
-  def set_system_channel(%{id: id}, channel_id), #Maybe Channel module should have a shortcut to this function?
+  def set_system_channel(%{id: id}, channel_id),
     do: set_system_channel(id, channel_id)
 
   def set_system_channel(guild, channel_id) do
@@ -168,12 +168,12 @@ defmodule Coxir.Struct.Guild do
   Returns a guild object upon success
   or a map containing error information.
   """
-  @spec transfer(guild, String.t) :: map
+  @spec transfer_ownership(guild, String.t) :: map
 
-  def transfer(%{id: id}, user_id),
-    do: transfer(id, user_id)
+  def transfer_ownership(%{id: id}, user_id),
+    do: transfer_ownership(id, user_id)
 
-  def transfer(guild, user_id) do
+  def transfer_ownership(guild, user_id) do
     edit(guild, %{owner_id: user_id})
   end
 
@@ -226,7 +226,6 @@ defmodule Coxir.Struct.Guild do
   - `verification_level` - verification level
   - `default_message_notifications` - default message notification level
   - `explicit_content_filter` - explicit content filter level
-
 
   Refer to [this](https://discordapp.com/developers/docs/resources/guild#modify-guild)
   for a broader explanation on the fields and their defaults.

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -103,7 +103,7 @@ defmodule Coxir.Struct.Guild do
   Returns a guild object upon success
   or a map containing error information.
   """
-  @spec set_region(guild, String.t) :: map
+  @spec set_icon(guild, String.t) :: map
 
   def set_icon(guild, icon),
     do: edit(guild, icon: icon)

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -87,7 +87,7 @@ defmodule Coxir.Struct.Guild do
   end
 
   @doc """
-  Modifies the name of a given guild.
+  Changes the name of a given guild.
 
   Returns a guild object upon success
   or a map containing error information.
@@ -98,7 +98,7 @@ defmodule Coxir.Struct.Guild do
     do: edit(guild, name: name)
 
   @doc """
-  Modifies the icon of a given guild.
+  Changes the icon of a given guild.
 
   Returns a guild object upon success
   or a map containing error information.
@@ -109,7 +109,7 @@ defmodule Coxir.Struct.Guild do
     do: edit(guild, icon: icon)
 
   @doc """
-  Modifies the region of a given guild.
+  Changes the region of a given guild.
 
   Returns a guild object upon success
   or a map containing error information.
@@ -120,7 +120,7 @@ defmodule Coxir.Struct.Guild do
     do: edit(guild, region: region)
 
   @doc """
-  Modifies the splash of a given guild.
+  Changes the splash of a given guild.
 
   Returns a guild object upon success
   or a map containing error information.
@@ -131,7 +131,7 @@ defmodule Coxir.Struct.Guild do
     do: edit(guild, splash: splash)
 
   @doc """
-  Modifies the voice AFK timeout of a given guild.
+  Changes the voice AFK timeout of a given guild.
 
   Returns a guild object upon success
   or a map containing error information.
@@ -142,7 +142,7 @@ defmodule Coxir.Struct.Guild do
     do: edit(guild, afk_timeout: timeout)
 
   @doc """
-  Modifies the voice AFK channel of a given guild.
+  Changes the voice AFK channel of a given guild.
 
   Returns a guild object upon success
   or a map containing error information.
@@ -153,7 +153,7 @@ defmodule Coxir.Struct.Guild do
     do: edit(guild, afk_channel_id: channel)
 
   @doc """
-  Modifies the channel to which system messages are sent on a given guild.
+  Changes the channel to which system messages are sent on a given guild.
 
   Returns a guild object upon success
   or a map containing error information.

--- a/lib/coxir/struct/invite.ex
+++ b/lib/coxir/struct/invite.ex
@@ -18,7 +18,6 @@ defmodule Coxir.Struct.Invite do
   Returns an invite object upon success
   or a map containing error information.
   """
-
   def get(code) do
     API.request(:get, "invites/#{code}")
   end

--- a/lib/coxir/struct/member.ex
+++ b/lib/coxir/struct/member.ex
@@ -92,6 +92,17 @@ defmodule Coxir.Struct.Member do
   end
 
   @doc """
+  Changes the voice channel of a given member.
+
+  Returns the atom `:ok` upon success
+  or a map containing error information.
+  """
+  @spec move(member, String.t) :: :ok | map
+
+  def move(member, channel),
+    do: edit(member, channel_id: channel)
+
+  @doc """
   Kicks a given member.
 
   Returns the atom `:ok` upon success

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -123,33 +123,18 @@ defmodule Coxir.Struct.Role do
   end
 
   @doc """
-  Enables mentioning a given role.
+  Modifies the mentioning status of a given role.
 
   Returns a role object upon success
   or a map containing error information.
   """
-  @spec enable_mentioning(role, String.t) :: map
+  @spec set_mentioning(role, String.t, Boolean.t) :: map
 
-  def enable_mentioning(%{id: id, guild_id: guild}),
-    do: enable_mentioning(id, guild)
+  def set_mentioning(%{id: id, guild_id: guild}, state),
+    do: set_mentioning(id, guild, state)
 
-  def enable_mentioning(role, guild) do
-    edit(role, guild, mentionable: true)
-  end
-
-  @doc """
-  Disables mentioning a given role.
-
-  Returns a role object upon success
-  or a map containing error information.
-  """
-  @spec disable_mentioning(role, String.t) :: map
-
-  def disable_mentioning(%{id: id, guild_id: guild}),
-    do: disable_mentioning(id, guild)
-
-  def disable_mentioning(role, guild) do
-    edit(role, guild, mentionable: false)
+  def set_mentioning(role, guild, state) do
+    edit(role, guild, mentionable: state)
   end
 
   @doc """

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -61,9 +61,8 @@ defmodule Coxir.Struct.Role do
   def set_name(%{id: id, guild_id: guild}, name),
     do: set_name(id, guild, name)
 
-  def set_name(role, guild_id, name) do
-    edit(role, guild_id, %{name: name})
-  end
+  def set_name(role, guild, name),
+    do: edit(role, guild, name: name)
 
   @doc """
   Modifies the color of a given role.
@@ -76,9 +75,8 @@ defmodule Coxir.Struct.Role do
   def set_color(%{id: id, guild_id: guild}, color),
     do: set_color(id, guild, color)
 
-  def set_color(role, guild_id, color) do
-    edit(role, guild_id, %{color: color})
-  end
+  def set_color(role, guild, color),
+    do: edit(role, guild, color: color)
 
   @doc """
   Modifies the permissions of a given role.
@@ -91,9 +89,8 @@ defmodule Coxir.Struct.Role do
   def set_permissions(%{id: id, guild_id: guild}, permissions),
     do: set_permissions(id, guild, permissions)
 
-  def set_permissions(role, guild_id, permissions) do
-    edit(role, guild_id, %{permissions: permissions})
-  end
+  def set_permissions(role, guild, permissions),
+    do: edit(role, guild, permissions: permissions)
 
   @doc """
   Hoists a given role.
@@ -106,8 +103,8 @@ defmodule Coxir.Struct.Role do
   def hoist(%{id: id, guild_id: guild}),
     do: hoist(id, guild)
 
-  def hoist(role, guild_id) do
-    edit(role, guild_id, %{hoist: true})
+  def hoist(role, guild) do
+    edit(role, guild, hoist: true)
   end
 
   @doc """
@@ -121,8 +118,8 @@ defmodule Coxir.Struct.Role do
   def unhoist(%{id: id, guild_id: guild}),
     do: unhoist(id, guild)
 
-  def unhoist(role, guild_id) do
-    edit(role, guild_id, %{hoist: false})
+  def unhoist(role, guild) do
+    edit(role, guild, hoist: false)
   end
 
   @doc """
@@ -136,8 +133,8 @@ defmodule Coxir.Struct.Role do
   def enable_mentioning(%{id: id, guild_id: guild}),
     do: enable_mentioning(id, guild)
 
-  def enable_mentioning(role, guild_id) do
-    edit(role, guild_id, %{mentionable: true})
+  def enable_mentioning(role, guild) do
+    edit(role, guild, mentionable: true)
   end
 
   @doc """
@@ -151,8 +148,8 @@ defmodule Coxir.Struct.Role do
   def disable_mentioning(%{id: id, guild_id: guild}),
     do: disable_mentioning(id, guild)
 
-  def disable_mentioning(role, guild_id) do
-    edit(role, guild_id, %{mentionable: false})
+  def disable_mentioning(role, guild) do
+    edit(role, guild, mentionable: false)
   end
 
   @doc """

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -101,7 +101,7 @@ defmodule Coxir.Struct.Role do
   @spec set_hoist(role, Boolean.t) :: map
 
   def set_hoist(%{id: id, guild_id: guild}, state),
-    do: hoist(id, guild, state)
+    do: set_hoist(id, guild, state)
 
   def set_hoist(role, guild, state) do
     edit(role, guild, hoist: state)

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -39,7 +39,7 @@ defmodule Coxir.Struct.Role do
   """
   @spec set_color(role, String.t, Integer.t) :: map
 
-  def set_color(%{id: id, guild_id: guild}, color), #Role.set_color("role_id", "guild_id", color)
+  def set_color(%{id: id, guild_id: guild}, color),
     do: set_color(id, guild, color)
 
   def set_color(role, guild_id, color) do

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -93,33 +93,18 @@ defmodule Coxir.Struct.Role do
     do: edit(role, guild, permissions: permissions)
 
   @doc """
-  Hoists a given role.
+  Modifies the hoisting of a given role.
 
   Returns a role object upon success
   or a map containing error information.
   """
-  @spec hoist(role, String.t) :: map
+  @spec set_hoist(role, String.t, Boolean.t) :: map
 
-  def hoist(%{id: id, guild_id: guild}),
-    do: hoist(id, guild)
+  def set_hoist(%{id: id, guild_id: guild}, state),
+    do: hoist(id, guild, state)
 
-  def hoist(role, guild) do
-    edit(role, guild, hoist: true)
-  end
-
-  @doc """
-  Unhoists a given role.
-
-  Returns a role object upon success
-  or a map containing error information.
-  """
-  @spec unhoist(role, String.t) :: map
-
-  def unhoist(%{id: id, guild_id: guild}),
-    do: unhoist(id, guild)
-
-  def unhoist(role, guild) do
-    edit(role, guild, hoist: false)
+  def set_hoist(role, guild, state) do
+    edit(role, guild, hoist: state)
   end
 
   @doc """

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -17,6 +17,111 @@ defmodule Coxir.Struct.Role do
   def select(pattern)
 
   @doc """
+  Modifies the name of a given role.
+
+  Returns a role object upon success
+  or a map containing error information.
+  """
+  @spec set_name(role, String.t, String.t) :: map
+
+  def set_name(%{id: id, guild_id: guild}, name),
+    do: set_name(id, guild, name)
+
+  def set_name(role, guild_id, name) do
+    edit(role, guild_id, %{name: name})
+  end
+
+  @doc """
+  Modifies the color of a given role.
+
+  Returns a role object upon success
+  or a map containing error information.
+  """
+  @spec set_color(role, String.t, Integer.t) :: map
+
+  def set_color(%{id: id, guild_id: guild}, color), #Role.set_color("role_id", "guild_id", color)
+    do: set_color(id, guild, color)
+
+  def set_color(role, guild_id, color) do
+    edit(role, guild_id, %{color: color})
+  end
+
+  @doc """
+  Modifies the permissions of a given role.
+
+  Returns a role object upon success
+  or a map containing error information.
+  """
+  @spec set_permissions(role, String.t, Integer.t) :: map
+
+  def set_permissions(%{id: id, guild_id: guild}, permissions),
+    do: set_permissions(id, guild, permissions)
+
+  def set_permissions(role, guild_id, permissions) do
+    edit(role, guild_id, %{permissions: permissions})
+  end
+
+  @doc """
+  Hoists a given role.
+
+  Returns a role object upon success
+  or a map containing error information.
+  """
+  @spec hoist(role, String.t) :: map
+
+  def hoist(%{id: id, guild_id: guild}),
+    do: hoist(id, guild)
+
+  def hoist(role, guild_id) do
+    edit(role, guild_id, %{hoist: true})
+  end
+
+  @doc """
+  Unhoists a given role.
+
+  Returns a role object upon success
+  or a map containing error information.
+  """
+  @spec unhoist(role, String.t) :: map
+
+  def unhoist(%{id: id, guild_id: guild}),
+    do: unhoist(id, guild)
+
+  def unhoist(role, guild_id) do
+    edit(role, guild_id, %{hoist: false})
+  end
+
+  @doc """
+  Enables mentioning a given role.
+
+  Returns a role object upon success
+  or a map containing error information.
+  """
+  @spec enable_mentioning(role, String.t) :: map
+
+  def enable_mentioning(%{id: id, guild_id: guild}),
+    do: enable_mentioning(id, guild)
+
+  def enable_mentioning(role, guild_id) do
+    edit(role, guild_id, %{mentionable: true})
+  end
+
+  @doc """
+  Disables mentioning a given role.
+
+  Returns a role object upon success
+  or a map containing error information.
+  """
+  @spec disable_mentioning(role, String.t) :: map
+
+  def disable_mentioning(%{id: id, guild_id: guild}),
+    do: disable_mentioning(id, guild)
+
+  def disable_mentioning(role, guild_id) do
+    edit(role, guild_id, %{mentionable: false})
+  end
+
+  @doc """
   Modifies a given role.
 
   Returns a role object upon success

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -17,6 +17,40 @@ defmodule Coxir.Struct.Role do
   def select(pattern)
 
   @doc """
+  Modifies a given role.
+
+  Returns a role object upon success
+  or a map containing error information.
+
+  #### Params
+  Must be an enumerable with the fields listed below.
+  - `name` - name of the role
+  - `color` - RGB color value
+  - `permissions` - bitwise of the permissions
+  - `hoist` - whether the role should be displayed separately
+  - `mentionable` - whether the role should be mentionable
+
+  Refer to [this](https://discordapp.com/developers/docs/resources/guild#modify-guild-role)
+  for a broader explanation on the fields and their defaults.
+  """
+  @spec edit(role, Enum.t) :: map
+
+  def edit(%{id: id, guild_id: guild}, params),
+    do: edit(id, guild, params)
+
+  @doc """
+  Modifies a given role.
+
+  Refer to `edit/2` for more information.
+  """
+  @spec edit(String.t, String.t, Enum.t) :: map
+
+  def edit(role, guild, params) do
+    API.request(:patch, "guilds/#{guild}/roles/#{role}", params)
+    |> put(:guild_id, guild)
+  end
+
+  @doc """
   Modifies the name of a given role.
 
   Returns a role object upon success
@@ -119,40 +153,6 @@ defmodule Coxir.Struct.Role do
 
   def disable_mentioning(role, guild_id) do
     edit(role, guild_id, %{mentionable: false})
-  end
-
-  @doc """
-  Modifies a given role.
-
-  Returns a role object upon success
-  or a map containing error information.
-
-  #### Params
-  Must be an enumerable with the fields listed below.
-  - `name` - name of the role
-  - `color` - RGB color value
-  - `permissions` - bitwise of the permissions
-  - `hoist` - whether the role should be displayed separately
-  - `mentionable` - whether the role should be mentionable
-
-  Refer to [this](https://discordapp.com/developers/docs/resources/guild#modify-guild-role)
-  for a broader explanation on the fields and their defaults.
-  """
-  @spec edit(role, Enum.t) :: map
-
-  def edit(%{id: id, guild_id: guild}, params),
-    do: edit(id, guild, params)
-
-  @doc """
-  Modifies a given role.
-
-  Refer to `edit/2` for more information.
-  """
-  @spec edit(String.t, String.t, Enum.t) :: map
-
-  def edit(role, guild, params) do
-    API.request(:patch, "guilds/#{guild}/roles/#{role}", params)
-    |> put(:guild_id, guild)
   end
 
   @doc """

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -100,12 +100,11 @@ defmodule Coxir.Struct.Role do
   """
   @spec set_hoist(role, Boolean.t) :: map
 
-  def set_hoist(%{id: id, guild_id: guild}, state),
-    do: set_hoist(id, guild, state)
+  def set_hoist(%{id: id, guild_id: guild}, bool),
+    do: set_hoist(id, guild, bool)
 
-  def set_hoist(role, guild, state) do
-    edit(role, guild, hoist: state)
-  end
+  def set_hoist(role, guild, bool),
+    do: edit(role, guild, hoist: bool)
 
   @doc """
   Modifies the mentioning status of a given role.
@@ -113,14 +112,13 @@ defmodule Coxir.Struct.Role do
   Returns a role object upon success
   or a map containing error information.
   """
-  @spec set_mentioning(role, Boolean.t) :: map
+  @spec set_mentionable(role, Boolean.t) :: map
 
-  def set_mentioning(%{id: id, guild_id: guild}, state),
-    do: set_mentioning(id, guild, state)
+  def set_mentionable(%{id: id, guild_id: guild}, bool),
+    do: set_mentionable(id, guild, bool)
 
-  def set_mentioning(role, guild, state) do
-    edit(role, guild, mentionable: state)
-  end
+  def set_mentionable(role, guild, bool),
+    do: edit(role, guild, mentionable: bool)
 
   @doc """
   Deletes a given role.

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -98,7 +98,7 @@ defmodule Coxir.Struct.Role do
   Returns a role object upon success
   or a map containing error information.
   """
-  @spec set_hoist(role, Boolean.t) :: map
+  @spec set_hoist(role, boolean) :: map
 
   def set_hoist(%{id: id, guild_id: guild}, bool),
     do: set_hoist(id, guild, bool)
@@ -112,7 +112,7 @@ defmodule Coxir.Struct.Role do
   Returns a role object upon success
   or a map containing error information.
   """
-  @spec set_mentionable(role, Boolean.t) :: map
+  @spec set_mentionable(role, boolean) :: map
 
   def set_mentionable(%{id: id, guild_id: guild}, bool),
     do: set_mentionable(id, guild, bool)

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -93,7 +93,7 @@ defmodule Coxir.Struct.Role do
     do: edit(role, guild, permissions: permissions)
 
   @doc """
-  Modifies the hoisting of a given role.
+  Modifies the hoist flag of a given role.
 
   Returns a role object upon success
   or a map containing error information.
@@ -107,7 +107,7 @@ defmodule Coxir.Struct.Role do
     do: edit(role, guild, hoist: bool)
 
   @doc """
-  Modifies the mentioning status of a given role.
+  Modifies the mentionable flag of a given role.
 
   Returns a role object upon success
   or a map containing error information.

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -56,10 +56,17 @@ defmodule Coxir.Struct.Role do
   Returns a role object upon success
   or a map containing error information.
   """
-  @spec set_name(role, String.t, String.t) :: map
+  @spec set_name(role, String.t) :: map
 
   def set_name(%{id: id, guild_id: guild}, name),
     do: set_name(id, guild, name)
+
+  @doc """
+  Changes the name of a given role.
+
+  Refer to `set_name/2` for more information.
+  """
+  @spec set_name(String.t, String.t, String.t) :: map
 
   def set_name(role, guild, name),
     do: edit(role, guild, name: name)
@@ -70,10 +77,17 @@ defmodule Coxir.Struct.Role do
   Returns a role object upon success
   or a map containing error information.
   """
-  @spec set_color(role, String.t, Integer.t) :: map
+  @spec set_color(role, Integer.t) :: map
 
   def set_color(%{id: id, guild_id: guild}, color),
     do: set_color(id, guild, color)
+
+  @doc """
+  Changes the color of a given role.
+
+  Refer to `set_color/2` for more information.
+  """
+  @spec set_color(String.t, String.t, Integer.t) :: map
 
   def set_color(role, guild, color),
     do: edit(role, guild, color: color)
@@ -84,10 +98,17 @@ defmodule Coxir.Struct.Role do
   Returns a role object upon success
   or a map containing error information.
   """
-  @spec set_permissions(role, String.t, Integer.t) :: map
+  @spec set_permissions(role, Integer.t) :: map
 
   def set_permissions(%{id: id, guild_id: guild}, permissions),
     do: set_permissions(id, guild, permissions)
+
+  @doc """
+  Changes the permissions of a given role.
+
+  Refer to `set_permissions/2` for more information.
+  """
+  @spec set_permissions(String.t, String.t, Integer.t) :: map
 
   def set_permissions(role, guild, permissions),
     do: edit(role, guild, permissions: permissions)
@@ -103,6 +124,13 @@ defmodule Coxir.Struct.Role do
   def set_hoist(%{id: id, guild_id: guild}, bool),
     do: set_hoist(id, guild, bool)
 
+  @doc """
+  Changes the hoist flag of a given role.
+
+  Refer to `set_hoist/2` for more information.
+  """
+  @spec set_hoist(String.t, String.t, boolean) :: map
+
   def set_hoist(role, guild, bool),
     do: edit(role, guild, hoist: bool)
 
@@ -116,6 +144,13 @@ defmodule Coxir.Struct.Role do
 
   def set_mentionable(%{id: id, guild_id: guild}, bool),
     do: set_mentionable(id, guild, bool)
+
+  @doc """
+  Changes the mentionable flag of a given role.
+
+  Refer to `set_mentionable/2` for more information.
+  """
+  @spec set_mentionable(String.t, String.t, boolean) :: map
 
   def set_mentionable(role, guild, bool),
     do: edit(role, guild, mentionable: bool)

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -51,7 +51,7 @@ defmodule Coxir.Struct.Role do
   end
 
   @doc """
-  Modifies the name of a given role.
+  Changes the name of a given role.
 
   Returns a role object upon success
   or a map containing error information.
@@ -65,7 +65,7 @@ defmodule Coxir.Struct.Role do
     do: edit(role, guild, name: name)
 
   @doc """
-  Modifies the color of a given role.
+  Changes the color of a given role.
 
   Returns a role object upon success
   or a map containing error information.
@@ -79,7 +79,7 @@ defmodule Coxir.Struct.Role do
     do: edit(role, guild, color: color)
 
   @doc """
-  Modifies the permissions of a given role.
+  Changes the permissions of a given role.
 
   Returns a role object upon success
   or a map containing error information.
@@ -93,7 +93,7 @@ defmodule Coxir.Struct.Role do
     do: edit(role, guild, permissions: permissions)
 
   @doc """
-  Modifies the hoist flag of a given role.
+  Changes the hoist flag of a given role.
 
   Returns a role object upon success
   or a map containing error information.
@@ -107,7 +107,7 @@ defmodule Coxir.Struct.Role do
     do: edit(role, guild, hoist: bool)
 
   @doc """
-  Modifies the mentionable flag of a given role.
+  Changes the mentionable flag of a given role.
 
   Returns a role object upon success
   or a map containing error information.

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -98,7 +98,7 @@ defmodule Coxir.Struct.Role do
   Returns a role object upon success
   or a map containing error information.
   """
-  @spec set_hoist(role, String.t, Boolean.t) :: map
+  @spec set_hoist(role, Boolean.t) :: map
 
   def set_hoist(%{id: id, guild_id: guild}, state),
     do: hoist(id, guild, state)
@@ -113,7 +113,7 @@ defmodule Coxir.Struct.Role do
   Returns a role object upon success
   or a map containing error information.
   """
-  @spec set_mentioning(role, String.t, Boolean.t) :: map
+  @spec set_mentioning(role, Boolean.t) :: map
 
   def set_mentioning(%{id: id, guild_id: guild}, state),
     do: set_mentioning(id, guild, state)

--- a/lib/coxir/struct/webhook.ex
+++ b/lib/coxir/struct/webhook.ex
@@ -37,6 +37,42 @@ defmodule Coxir.Struct.Webhook do
   end
 
   @doc """
+  Modifies the name of a given webhook.
+
+  Returns a webhook object upon success
+  or a map containing error information.
+  """
+  @spec set_name(String.t, String.t) :: map
+
+  def set_name(webhook, name) do
+    edit(webhook, %{name: name})
+  end
+
+  @doc """
+  Modifies the avatar of a given webhook.
+
+  Returns a webhook object upon success
+  or a map containing error information.
+  """
+  @spec set_avatar(String.t, String.t) :: map
+
+  def set_avatar(webhook, avatar) do
+    edit(webhook, %{avatar: avatar})
+  end
+
+  @doc """
+  Moves a given webhook to a given channel.
+
+  Returns a webhook object upon success
+  or a map containing error information.
+  """
+  @spec set_channel(String.t, String.t) :: map
+
+  def set_channel(webhook, channel_id) do
+    edit(webhook, %{avatar: channel_id})
+  end
+
+  @doc """
   Modifies a given webhook.
 
   Returns a webhook object upon success

--- a/lib/coxir/struct/webhook.ex
+++ b/lib/coxir/struct/webhook.ex
@@ -94,7 +94,7 @@ defmodule Coxir.Struct.Webhook do
     do: edit(webhook, avatar: avatar)
 
   @doc """
-  Moves a given webhook to a given channel.
+  Modifies the channel of a given webhook.
 
   Returns a webhook object upon success
   or a map containing error information.

--- a/lib/coxir/struct/webhook.ex
+++ b/lib/coxir/struct/webhook.ex
@@ -79,9 +79,8 @@ defmodule Coxir.Struct.Webhook do
   """
   @spec set_name(String.t, String.t) :: map
 
-  def set_name(webhook, name) do
-    edit(webhook, %{name: name})
-  end
+  def set_name(webhook, name),
+    do: edit(webhook, name: name)
 
   @doc """
   Modifies the avatar of a given webhook.
@@ -91,9 +90,8 @@ defmodule Coxir.Struct.Webhook do
   """
   @spec set_avatar(String.t, String.t) :: map
 
-  def set_avatar(webhook, avatar) do
-    edit(webhook, %{avatar: avatar})
-  end
+  def set_avatar(webhook, avatar),
+    do: edit(webhook, avatar: avatar)
 
   @doc """
   Moves a given webhook to a given channel.
@@ -103,9 +101,8 @@ defmodule Coxir.Struct.Webhook do
   """
   @spec set_channel(String.t, String.t) :: map
 
-  def set_channel(webhook, channel_id) do
-    edit(webhook, %{avatar: channel_id})
-  end
+  def set_channel(webhook, channel_id),
+    do: edit(webhook, channel_id: channel_id)
 
   @doc """
   Deletes a given webhook.

--- a/lib/coxir/struct/webhook.ex
+++ b/lib/coxir/struct/webhook.ex
@@ -72,7 +72,7 @@ defmodule Coxir.Struct.Webhook do
   end
 
   @doc """
-  Modifies the name of a given webhook.
+  Changes the name of a given webhook.
 
   Returns a webhook object upon success
   or a map containing error information.
@@ -83,7 +83,7 @@ defmodule Coxir.Struct.Webhook do
     do: edit(webhook, name: name)
 
   @doc """
-  Modifies the avatar of a given webhook.
+  Changes the avatar of a given webhook.
 
   Returns a webhook object upon success
   or a map containing error information.
@@ -94,7 +94,7 @@ defmodule Coxir.Struct.Webhook do
     do: edit(webhook, avatar: avatar)
 
   @doc """
-  Modifies the channel of a given webhook.
+  Changes the channel of a given webhook.
 
   Returns a webhook object upon success
   or a map containing error information.

--- a/lib/coxir/struct/webhook.ex
+++ b/lib/coxir/struct/webhook.ex
@@ -101,8 +101,8 @@ defmodule Coxir.Struct.Webhook do
   """
   @spec set_channel(String.t, String.t) :: map
 
-  def set_channel(webhook, channel_id),
-    do: edit(webhook, channel_id: channel_id)
+  def set_channel(webhook, channel),
+    do: edit(webhook, channel_id: channel)
 
   @doc """
   Deletes a given webhook.

--- a/lib/coxir/struct/webhook.ex
+++ b/lib/coxir/struct/webhook.ex
@@ -17,7 +17,6 @@ defmodule Coxir.Struct.Webhook do
   Returns a webhook object upon success
   or a map containing error information.
   """
-
   def get(webhook) do
     API.request(:get, "webhooks/#{webhook}")
     |> pretty

--- a/lib/coxir/struct/webhook.ex
+++ b/lib/coxir/struct/webhook.ex
@@ -37,6 +37,41 @@ defmodule Coxir.Struct.Webhook do
   end
 
   @doc """
+  Modifies a given webhook.
+
+  Returns a webhook object upon success
+  or a map containing error information.
+
+  #### Params
+  Must be an enumerable with the fields listed below.
+  - `name` - the default name of the webhook
+  - `avatar` - image for the default webhook avatar
+  - `channel_id` - the new channel id to be moved to
+
+  Refer to [this](https://discordapp.com/developers/docs/resources/webhook#modify-webhook)
+  for a broader explanation on the fields and their defaults.
+  """
+  @spec edit(String.t, Enum.t) :: map
+
+  def edit(webhook, params) do
+    API.request(:patch, "webhooks/#{webhook}", params)
+    |> pretty
+  end
+
+  @doc """
+  Modifies a given webhook.
+
+  Refer to [this](https://discordapp.com/developers/docs/resources/webhook#modify-webhook-with-token)
+  for more information.
+  """
+  @spec edit_with_token(String.t, String.t, Enum.t) :: map
+
+  def edit_with_token(webhook, token, params) do
+    API.request(:patch, "webhooks/#{webhook}/#{token}", params)
+    |> pretty
+  end
+
+  @doc """
   Modifies the name of a given webhook.
 
   Returns a webhook object upon success
@@ -70,41 +105,6 @@ defmodule Coxir.Struct.Webhook do
 
   def set_channel(webhook, channel_id) do
     edit(webhook, %{avatar: channel_id})
-  end
-
-  @doc """
-  Modifies a given webhook.
-
-  Returns a webhook object upon success
-  or a map containing error information.
-
-  #### Params
-  Must be an enumerable with the fields listed below.
-  - `name` - the default name of the webhook
-  - `avatar` - image for the default webhook avatar
-  - `channel_id` - the new channel id to be moved to
-
-  Refer to [this](https://discordapp.com/developers/docs/resources/webhook#modify-webhook)
-  for a broader explanation on the fields and their defaults.
-  """
-  @spec edit(String.t, Enum.t) :: map
-
-  def edit(webhook, params) do
-    API.request(:patch, "webhooks/#{webhook}", params)
-    |> pretty
-  end
-
-  @doc """
-  Modifies a given webhook.
-
-  Refer to [this](https://discordapp.com/developers/docs/resources/webhook#modify-webhook-with-token)
-  for more information.
-  """
-  @spec edit_with_token(String.t, String.t, Enum.t) :: map
-
-  def edit_with_token(webhook, token, params) do
-    API.request(:patch, "webhooks/#{webhook}/#{token}", params)
-    |> pretty
   end
 
   @doc """


### PR DESCRIPTION
This pull request hands out the possibility of modifying channels', guilds', ... properties without having to keep in mind the structure that discord expects on a plain modify request.


### Several examples
```elixir
Channel.set_parent(message.channel.id, id)
Channel.set_position(message.channel.id, Integer.parse(position) |> elem(0)) #We receive position as a string.
Channel.enable_nsfw(message.channel.id)
Channel.set_topic(message.channel.id, name)
Channel.set_name(message.channel.id, name)
Guild.set_name(message.guild.id, name)
Webhook.set_name("id", "Coxir")
Role.set_color("role_id", "guild_id", color)
Role.enable_mentioning("role_id", "guild_id")
```