### PR TITLE
Added Guild.get_vanity_code/1

### DIFF
--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -553,4 +553,25 @@ defmodule Coxir.Struct.Guild do
   def get_regions do
     API.request(:get, "voice/regions")
   end
+  
+  @doc """
+  Fetches the vanity url code for a given guild.
+
+  Returns a string containig the vanity url
+  code or a map containing error information.
+  """
+  @spec get_vanity_url(guild) :: String.t | map
+
+  def get_vanity_url(%{id: id}),
+    do: get_vanity_url(id)
+
+  def get_vanity_url(guild) do
+    API.request(:get, "guilds/#{guild}/vanity-url")
+    |> case do
+      %{code: code, error: error} ->
+        %{code: code, error: error}
+      result ->
+        result[:code]
+    end
+  end
 end

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -568,10 +568,10 @@ defmodule Coxir.Struct.Guild do
   def get_vanity_url(guild) do
     API.request(:get, "guilds/#{guild}/vanity-url")
     |> case do
-      %{code: code, error: error} ->
-        %{code: code, error: error}
-      result ->
-        result[:code]
+      %{code: _, error: _} = result ->
+        result
+      other ->
+        other[:code]
     end
   end
 end

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -560,12 +560,12 @@ defmodule Coxir.Struct.Guild do
   Returns a string representing the code
   or a map containing error information.
   """
-  @spec get_vanity_url(guild) :: String.t | map
+  @spec get_vanity_code(guild) :: String.t | map
 
-  def get_vanity_url(%{id: id}),
-    do: get_vanity_url(id)
+  def get_vanity_code(%{id: id}),
+    do: get_vanity_code(id)
 
-  def get_vanity_url(guild) do
+  def get_vanity_code(guild) do
     API.request(:get, "guilds/#{guild}/vanity-url")
     |> case do
       %{error: _value} = error ->

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -555,10 +555,10 @@ defmodule Coxir.Struct.Guild do
   end
   
   @doc """
-  Fetches the vanity url code for a given guild.
+  Fetches the vanity url code of a given guild.
 
-  Returns a string containig the vanity url
-  code or a map containing error information.
+  Returns a string representing the code
+  or a map containing error information.
   """
   @spec get_vanity_url(guild) :: String.t | map
 
@@ -568,10 +568,10 @@ defmodule Coxir.Struct.Guild do
   def get_vanity_url(guild) do
     API.request(:get, "guilds/#{guild}/vanity-url")
     |> case do
-      %{code: _, error: _} = result ->
-        result
-      other ->
-        other[:code]
+      %{error: _value} = error ->
+        error
+      invite ->
+        invite[:code]
     end
   end
 end


### PR DESCRIPTION
This function requires to have MANAGE_GUILD permission.

It will return the code used in the vanity url or an error.