### PR TITLE
Added shortcut to Guild.leave/1

### DIFF
--- a/lib/coxir/struct/user.ex
+++ b/lib/coxir/struct/user.ex
@@ -12,7 +12,7 @@ defmodule Coxir.Struct.User do
 
   use Coxir.Struct
 
-  alias Coxir.Struct.{Channel}
+  alias Coxir.Struct.{Channel, Guild}
 
   def pretty(struct) do
     struct

--- a/lib/coxir/struct/user.ex
+++ b/lib/coxir/struct/user.ex
@@ -104,6 +104,21 @@ defmodule Coxir.Struct.User do
   def get_guilds(query \\ []) do
     API.request(:get, "users/@me/guilds", "", params: query)
   end
+  
+  @doc """
+  Leaves from a given guild.
+
+  Returns the atom `:ok` upon success
+  or a map containing error information.
+  """
+  @spec leave(guild) :: :ok | map
+
+  def leave(%{id: id}),
+    do: leave(id)
+
+  def leave(guild) do
+    Guild.leave(guild)
+  end
 
   @doc """
   Creates a DM channel with a given user.

--- a/lib/coxir/struct/user.ex
+++ b/lib/coxir/struct/user.ex
@@ -111,7 +111,7 @@ defmodule Coxir.Struct.User do
   Returns the atom `:ok` upon success
   or a map containing error information.
   """
-  @spec leave(guild) :: :ok | map
+  @spec leave(String.t | map) :: :ok | map
 
   def leave(%{id: id}),
     do: leave(id)


### PR DESCRIPTION
I thought this should be here as well since it is something that is related to `@me` / local user.