### PR TITLE
Added `User.set_username/1` and `User.set_avatar/1`

### DIFF
--- a/lib/coxir/struct/user.ex
+++ b/lib/coxir/struct/user.ex
@@ -116,6 +116,7 @@ defmodule Coxir.Struct.User do
           {:error, reason} ->
             reason = reason
             |> :file.format_error
+            |> List.to_string
 
             %{error: reason}
         end

--- a/lib/coxir/struct/user.ex
+++ b/lib/coxir/struct/user.ex
@@ -71,6 +71,41 @@ defmodule Coxir.Struct.User do
   def edit(params) do
     API.request(:patch, "users/@me", params)
   end
+  
+  @doc """
+  Modifies the username of the local user.
+
+  Returns a user object upon success
+  or a map containing error information.
+  """
+  @spec set_username(String.t) :: map
+
+  def set_username(username) do
+    edit(username: username)
+  end
+
+  @doc """
+  Modifies the avatar of the local user.
+
+  Returns a user object upon success
+  or a map containing error information.
+  """
+  @spec set_avatar(String.t) :: map
+
+  def set_avatar(avatar) do
+    avatar = String.contains?(avatar, "data:") and avatar or (
+      if !String.contains?(avatar, "data:") do
+        File.read(avatar)
+        |> case do
+          {:ok, content} ->
+            "data:;base64," <> Base.encode64(content)
+          other ->
+            other
+        end
+      end
+    )
+    edit(avatar: avatar)
+  end
 
   @doc """
   Fetches a list of connections for the local user.

--- a/lib/coxir/struct/user.ex
+++ b/lib/coxir/struct/user.ex
@@ -94,14 +94,12 @@ defmodule Coxir.Struct.User do
 
   def set_avatar(avatar) do
     avatar = String.contains?(avatar, "data:") and avatar or (
-      if !String.contains?(avatar, "data:") do
-        File.read(avatar)
-        |> case do
-          {:ok, content} ->
-            "data:;base64," <> Base.encode64(content)
-          other ->
-            other
-        end
+      File.read(avatar)
+      |> case do
+        {:ok, content} ->
+          "data:;base64," <> Base.encode64(content)
+        other ->
+          other
       end
     )
     edit(avatar: avatar)


### PR DESCRIPTION
Added `set_username/1` as a simple shortcut.

`set_avatar/1` expects either a base64 encoded string - Discord`s base64 format OR a path to read the content of an image.