### PR TITLE
Added Guild.is_lazy?/1

### DIFF
--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -574,4 +574,20 @@ defmodule Coxir.Struct.Guild do
         invite[:code]
     end
   end
+  
+  @doc """
+  Returns whether the given guild is lazy.
+
+  Returns a boolean.
+  """
+  @spec is_lazy(guild) :: String.t | map
+
+  def is_lazy(id) when is_binary(id) do
+    get(id)
+    |> is_lazy
+  end
+
+  def is_lazy(guild) do
+    guild[:large] == true
+  end
 end

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -580,7 +580,7 @@ defmodule Coxir.Struct.Guild do
 
   Returns a boolean.
   """
-  @spec is_lazy(guild) :: String.t | map
+  @spec is_lazy(guild) :: Boolean.t
 
   def is_lazy(id) when is_binary(id) do
     get(id)

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -576,18 +576,19 @@ defmodule Coxir.Struct.Guild do
   end
   
   @doc """
-  Returns whether the given guild is lazy.
+  Checks whether a given guild is lazy.
 
   Returns a boolean.
   """
-  @spec is_lazy(guild) :: Boolean.t
+  @spec is_lazy?(guild) :: boolean
 
-  def is_lazy(id) when is_binary(id) do
+  def is_lazy?(id) when is_binary(id) do
     get(id)
-    |> is_lazy
+    |> is_lazy?
   end
 
-  def is_lazy(guild) do
-    guild[:large] == true
+  def is_lazy?(guild) do
+    guild[:lazy]
+    == true
   end
 end


### PR DESCRIPTION
Added this guild property as Discord rolled this feature [a few weeks ago](https://github.com/discordapp/discord-api-docs/issues/582) for big servers who now have lazy loading.

This function accepts both, an id and a guild map.

![img](https://i.imgur.com/V4GAcFS.png)