### PR TITLE
Added Guild.get_ban/2

### DIFF
--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -439,11 +439,10 @@ defmodule Coxir.Struct.Guild do
   end
   
   @doc """
-  Retrieves the ban information for the given member.
+  Fetches the ban for an user on a given guild.
 
-  Returns a ban object for the given user
-  or a map containing error information.
-
+  Returns a ban object or a map
+  containing error information.
   """
   @spec get_ban(guild, String.t) :: map
 

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -437,6 +437,22 @@ defmodule Coxir.Struct.Guild do
   def get_bans(guild) do
     API.request(:get, "guilds/#{guild}/bans")
   end
+  
+  @doc """
+  Retrieves the ban information for the given member.
+
+  Returns a ban object for the given user
+  or a map containing error information.
+
+  """
+  @spec get_ban(guild, String.t) :: map
+
+  def get_ban(%{id: id}, user),
+    do: get_ban(id, user)
+
+  def get_ban(guild, user) do
+    API.request(:get, "guilds/#{guild}/bans/#{user}")
+  end
 
   @doc """
   Removes the ban for an user on a given guild.

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -6,7 +6,7 @@ defmodule Coxir.Struct.Guild do
   for a list of fields and a broader documentation.
 
   In addition, the following fields are also embedded.
-  - `owner` - an user object
+  - `owner` - a user object
   - `afk_channel` - a channel object
   - `embed_channel` - a channel object
   - `system_channel` - a channel object
@@ -304,7 +304,7 @@ defmodule Coxir.Struct.Guild do
   end
 
   @doc """
-  Adds an user to a given guild.
+  Adds a user to a given guild.
 
   Returns a member object upon success
   or a map containing error information.
@@ -439,7 +439,7 @@ defmodule Coxir.Struct.Guild do
   end
   
   @doc """
-  Fetches the ban for an user on a given guild.
+  Fetches the ban for a user on a given guild.
 
   Returns a ban object or a map
   containing error information.
@@ -454,7 +454,7 @@ defmodule Coxir.Struct.Guild do
   end
 
   @doc """
-  Removes the ban for an user on a given guild.
+  Removes the ban for a user on a given guild.
 
   Returns the atom `:ok` upon success
   or a map containing error information.

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -6,7 +6,7 @@ defmodule Coxir.Struct.Guild do
   for a list of fields and a broader documentation.
 
   In addition, the following fields are also embedded.
-  - `owner` - a user object
+  - `owner` - an user object
   - `afk_channel` - a channel object
   - `embed_channel` - a channel object
   - `system_channel` - a channel object
@@ -304,7 +304,7 @@ defmodule Coxir.Struct.Guild do
   end
 
   @doc """
-  Adds a user to a given guild.
+  Adds an user to a given guild.
 
   Returns a member object upon success
   or a map containing error information.
@@ -439,7 +439,7 @@ defmodule Coxir.Struct.Guild do
   end
   
   @doc """
-  Fetches the ban for a user on a given guild.
+  Fetches the ban for an user on a given guild.
 
   Returns a ban object or a map
   containing error information.
@@ -454,7 +454,7 @@ defmodule Coxir.Struct.Guild do
   end
 
   @doc """
-  Removes the ban for a user on a given guild.
+  Removes the ban for an user on a given guild.
 
   Returns the atom `:ok` upon success
   or a map containing error information.

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -441,8 +441,8 @@ defmodule Coxir.Struct.Guild do
   @doc """
   Fetches the ban for a user on a given guild.
 
-  Returns a ban object or a map
-  containing error information.
+  Returns a ban object
+  or a map containing error information.
   """
   @spec get_ban(guild, String.t) :: map
 


### PR DESCRIPTION
Added missing function `get_ban/2` which retrieves a [ban object](https://discordapp.com/developers/docs/resources/guild#ban-object).

This function should not be added in Member struct given that banned users are not Members anymore, and therefore we will not be able to retrieve a member object from Discord either. [example](https://i.imgur.com/DjEiFl0.png)

![img](https://i.imgur.com/RJmxZ6U.png)