### PR TITLE
Memory usage fix

### DIFF
--- a/lib/coxir.ex
+++ b/lib/coxir.ex
@@ -22,6 +22,7 @@ defmodule Coxir do
 
   @doc false
   def start(_type, _args) do
+    :erlang.system_flag(:fullsweep_after, 0)
     children = [
       supervisor(Voice, []),
       supervisor(Stage, []),

--- a/lib/coxir.ex
+++ b/lib/coxir.ex
@@ -22,7 +22,6 @@ defmodule Coxir do
 
   @doc false
   def start(_type, _args) do
-    :erlang.system_flag(:fullsweep_after, 0)
     children = [
       supervisor(Voice, []),
       supervisor(Stage, []),

--- a/lib/coxir/api/base.ex
+++ b/lib/coxir/api/base.ex
@@ -17,7 +17,7 @@ defmodule Coxir.API.Base do
   def process_request_body(body) do
     body
     |> Map.new
-    |> Jason.encode!
+    |> Poison.encode!
   end
 
   def process_request_headers(headers) do
@@ -32,7 +32,7 @@ defmodule Coxir.API.Base do
 
   def process_response_body(""), do: ""
   def process_response_body(body) do
-    Jason.decode!(body, keys: :atoms)
+    Poison.decode!(body, keys: :atoms)
   end
 
   def process_headers(headers) do

--- a/lib/coxir/gateway/worker.ex
+++ b/lib/coxir/gateway/worker.ex
@@ -112,12 +112,12 @@ defmodule Coxir.Gateway.Worker do
 
   defp parse(term) do
     term
-    |> Jason.decode!(keys: :atoms)
+    |> Poison.decode!(keys: :atoms)
   end
 
   defp encode(term) do
     term
-    |> Jason.encode!
+    |> Poison.encode!
   end
 
   defp payload(data, op) do

--- a/lib/coxir/stage.ex
+++ b/lib/coxir/stage.ex
@@ -9,12 +9,9 @@ defmodule Coxir.Stage do
 
   def start_link do
     children = [
-      worker(Producer, [])
+      worker(Producer, []),
+      worker(Middle, [], [id: 1])
     ]
-    ++ \
-    for index <- 1..@limit do
-      worker(Middle, [], [id: index])
-    end
     options = [
       strategy: :one_for_one,
       name: __MODULE__

--- a/lib/coxir/stage/consumer.ex
+++ b/lib/coxir/stage/consumer.ex
@@ -8,10 +8,9 @@ defmodule Coxir.Stage.Consumer do
   def start_link(handler) do
     state = %{
       handler: handler,
-      public: [],
-      fullsweep_after: 0
+      public: []
     }
-    GenStage.start_link __MODULE__, state
+    GenStage.start_link(__MODULE__, state, spawn_opt: [fullsweep_after: 0])
   end
 
   def init(state) do

--- a/lib/coxir/stage/consumer.ex
+++ b/lib/coxir/stage/consumer.ex
@@ -10,7 +10,7 @@ defmodule Coxir.Stage.Consumer do
       handler: handler,
       public: []
     }
-    GenStage.start_link(__MODULE__, state, spawn_opt: [fullsweep_after: 0])
+    GenStage.start_link(__MODULE__, state)
   end
 
   def init(state) do

--- a/lib/coxir/stage/consumer.ex
+++ b/lib/coxir/stage/consumer.ex
@@ -24,9 +24,7 @@ defmodule Coxir.Stage.Consumer do
 
   def handle(_handler, [], state), do: state
   def handle(handler, [event | events], state) do
-    handler
-    |> apply(:handle_event, [event, state])
-    |> case do
+    case handler.handle_event(event, state) do
       {:ok, state} ->
         handle(handler, events, state)
       term ->

--- a/lib/coxir/stage/consumer.ex
+++ b/lib/coxir/stage/consumer.ex
@@ -8,7 +8,8 @@ defmodule Coxir.Stage.Consumer do
   def start_link(handler) do
     state = %{
       handler: handler,
-      public: []
+      public: [],
+      fullsweep_after: 0
     }
     GenStage.start_link __MODULE__, state
   end
@@ -19,7 +20,7 @@ defmodule Coxir.Stage.Consumer do
 
   def handle_events(events, _from, %{handler: handler, public: public} = state) do
     public = handle(handler, events, public)
-    {:noreply, [], %{state | public: public}}
+    {:noreply, [], %{state | public: public}, :hibernate}
   end
 
   def handle(_handler, [], state), do: state

--- a/lib/coxir/stage/middle.ex
+++ b/lib/coxir/stage/middle.ex
@@ -8,7 +8,7 @@ defmodule Coxir.Stage.Middle do
   alias Coxir.Struct.{Guild, Role, Member, Channel, Message, User}
 
   def start_link do
-    GenStage.start_link __MODULE__, :ok, fullsweep_after: 0
+    GenStage.start_link __MODULE__, :ok
   end
 
   def init(state) do

--- a/lib/coxir/stage/middle.ex
+++ b/lib/coxir/stage/middle.ex
@@ -8,11 +8,11 @@ defmodule Coxir.Stage.Middle do
   alias Coxir.Struct.{Guild, Role, Member, Channel, Message, User}
 
   def start_link do
-    GenStage.start_link __MODULE__, :ok
+    GenStage.start_link __MODULE__, :ok, fullsweep_after: 0
   end
 
   def init(state) do
-    {:producer_consumer, state, subscribe_to: [Producer]}
+    {:producer_consumer, state, [subscribe_to: [Producer], buffer_size: 2000]}
   end
 
   def handle_events(events, _from, state) do

--- a/lib/coxir/stage/producer.ex
+++ b/lib/coxir/stage/producer.ex
@@ -4,11 +4,11 @@ defmodule Coxir.Stage.Producer do
   use GenStage
 
   def start_link do
-    GenStage.start_link __MODULE__, [], name: __MODULE__
+    GenStage.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def init(_state) do
-    {:producer, {:queue.new(), 0}}
+    {:producer, {:queue.new(), 0}, buffer_size: 2000}
   end
 
   def notify(event) do

--- a/lib/coxir/struct/struct.ex
+++ b/lib/coxir/struct/struct.ex
@@ -106,7 +106,6 @@ defmodule Coxir.Struct do
           struct ->
             Map.merge(struct, data)
         end
-
         :ets.insert @table, encode(data)
       end
 
@@ -120,9 +119,18 @@ defmodule Coxir.Struct do
       end
 
       defp encode(data) do
+        id = \
+        case data.id do
+          {a, b} ->
+            {:binary.copy(a), :binary.copy(b)}
+
+          id ->
+            :binary.copy(id)
+        end
+        
         data
         |> Map.to_list
-        |> List.insert_at(0, {:id, data.id})
+        |> List.insert_at(0, {:id, id})
         |> List.to_tuple
       end
 

--- a/lib/coxir/voice/gateway.ex
+++ b/lib/coxir/voice/gateway.ex
@@ -148,12 +148,12 @@ defmodule Coxir.Voice.Gateway do
 
   defp parse(term) do
     term
-    |> Jason.decode!(keys: :atoms)
+    |> Poison.decode!(keys: :atoms)
   end
 
   defp encode(term) do
     term
-    |> Jason.encode!
+    |> Poison.encode!
   end
 
   defp payload(data, op) do

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Coxir.Mixfile do
   defp deps do
     [
       {:kcl, "~> 1.1"},
-      {:jason, "~> 1.1"},
+      {:poison, "~> 3.1"},
       {:porcelain, "~> 2.0"},
       {:websockex, "~> 0.4.1"},
       {:httpoison, "~> 0.13.0"},


### PR DESCRIPTION
Setting this system flag to 0 makes all the processes created to spawn with `:fullsweep_after = 0` which makes the GC to come in to clean data as soon as possible.

I have been monitoring Coxir with this change and the memory used by processes has lowered around 35% (from 180-190MBs to 100MBs *and from time to time it stays at 70MBs*).

I am still investigating a proper way to improve the memory usage but this can work as a temporary fix.