### PR TITLE
TTL based ETS/Cache

### DIFF
--- a/lib/coxir/cache/cache.ex
+++ b/lib/coxir/cache/cache.ex
@@ -1,0 +1,5 @@
+defmodule Coxir.Cache.Cache do
+  @callback insert(cache :: Atom.t, data :: Tuple.t) :: Boolean.t
+  @callback get(cache :: Atom.t, data :: Tuple.t) :: List.t
+  @callback delete(cache :: Atom.t, data :: Tuple.t) :: Boolean.t
+end

--- a/lib/coxir/cache/ets.ex
+++ b/lib/coxir/cache/ets.ex
@@ -1,0 +1,7 @@
+defmodule Coxir.Cache.ETS do
+  @behaviour Coxir.Cache.Cache
+
+  defdelegate insert(cache, data), to: :ets
+  defdelegate get(cache, data), to: :ets, as: :lookup
+  defdelegate delete(cache, data), to: :ets
+end

--- a/lib/coxir/cache/ttl.ex
+++ b/lib/coxir/cache/ttl.ex
@@ -2,17 +2,20 @@ defmodule Coxir.Cache.TTL do
   @behaviour Coxir.Cache.Cache
 
   def insert(cache, data) do
-    "#{cache}s" |> String.to_atom
+    "#{cache}s"
+    |> String.to_atom()
     |> SimpleTTL.put(data)
   end
+
   def get(cache, data) do
-    "#{cache}s" |> String.to_atom
+    "#{cache}s"
+    |> String.to_atom()
     |> SimpleTTL.get(data)
   end
+
   def delete(cache, data) do
-    IO.inspect(data) 
-    "#{cache}s" |> String.to_atom
+    "#{cache}s"
+    |> String.to_atom()
     |> SimpleTTL.delete(data)
   end
-
 end

--- a/lib/coxir/cache/ttl.ex
+++ b/lib/coxir/cache/ttl.ex
@@ -1,0 +1,18 @@
+defmodule Coxir.Cache.TTL do
+  @behaviour Coxir.Cache.Cache
+
+  def insert(cache, data) do
+    "#{cache}s" |> String.to_atom
+    |> SimpleTTL.put(data)
+  end
+  def get(cache, data) do
+    "#{cache}s" |> String.to_atom
+    |> SimpleTTL.get(data)
+  end
+  def delete(cache, data) do
+    IO.inspect(data) 
+    "#{cache}s" |> String.to_atom
+    |> SimpleTTL.delete(data)
+  end
+
+end

--- a/lib/coxir/struct/channel.ex
+++ b/lib/coxir/struct/channel.ex
@@ -18,6 +18,33 @@ defmodule Coxir.Struct.Channel do
     struct
     |> replace(:owner_id, &User.get/1)
   end
+  
+  @doc """
+  Fetches a cached channel object.
+  If not found, it will get requested through the API.
+
+  Returns an object if found and `nil` otherwise.
+  """
+  @spec get(String.t()) :: map | nil
+
+  def get(id) do
+    super(id)
+    |> case do
+      nil ->
+        API.request(:get, "channels/#{id}")
+        |> case do
+          %{error: _value} = error ->
+            error
+
+          channel ->
+            update(channel)
+            pretty(channel)
+        end
+
+      channel ->
+        channel
+    end
+  end
 
   @doc """
   Sends a message to a given channel.

--- a/lib/coxir/struct/guild.ex
+++ b/lib/coxir/struct/guild.ex
@@ -33,6 +33,33 @@ defmodule Coxir.Struct.Guild do
     |> replace(:members, &Member.get/1)
     |> replace(:roles, &Role.get/1)
   end
+  
+  @doc """
+  Fetches a cached guild object.
+  If not found, it will get requested through the API.
+
+  Returns an object if found and `nil` otherwise.
+  """
+  @spec get(String.t()) :: map | nil
+
+  def get(id) do
+    super(id)
+    |> case do
+      nil ->
+        API.request(:get, "guilds/#{id}")
+        |> case do
+          %{error: _value} = error ->
+            error
+
+          guild ->
+            update(guild)
+            pretty(guild)
+        end
+
+      guild ->
+        guild
+    end
+  end
 
   @doc """
   Used to grab the shard of a given guild.

--- a/lib/coxir/struct/member.ex
+++ b/lib/coxir/struct/member.ex
@@ -57,6 +57,7 @@ defmodule Coxir.Struct.Member do
                 id: {guild, member.user.id},
                 user_id: member.user.id
               })
+              |> Map.update(:roles, [], &(Role.get(&1, guild)))
 
             update(member)
             pretty(member)

--- a/lib/coxir/struct/member.ex
+++ b/lib/coxir/struct/member.ex
@@ -51,6 +51,13 @@ defmodule Coxir.Struct.Member do
             error
 
           member ->
+            member =
+              member
+              |> Map.merge(%{
+                id: {member.guild_id, member.user.id},
+                user_id: member.user.id
+              })
+
             update(member)
             pretty(member)
         end
@@ -59,6 +66,7 @@ defmodule Coxir.Struct.Member do
         member
     end
   end
+  
   @doc """
   Modifies a given member.
 

--- a/lib/coxir/struct/member.ex
+++ b/lib/coxir/struct/member.ex
@@ -27,6 +27,7 @@ defmodule Coxir.Struct.Member do
 
   @doc """
   Fetches a cached member object.
+  If not found, it will get requested through the API.
 
   Returns an object if found and `nil` otherwise.
   """
@@ -38,10 +39,26 @@ defmodule Coxir.Struct.Member do
   def get(server, member),
     do: get({server, member})
 
-  @doc false
-  def get(id),
-    do: super(id)
+  def get(id) do
+    super(id)
+    |> case do
+      nil ->
+        {guild, user} = id
 
+        API.request(:get, "/guilds/#{guild}/members/#{user}")
+        |> case do
+          %{error: _value} = error ->
+            error
+
+          member ->
+            update(member)
+            pretty(member)
+        end
+
+      member ->
+        member
+    end
+  end
   @doc """
   Modifies a given member.
 

--- a/lib/coxir/struct/member.ex
+++ b/lib/coxir/struct/member.ex
@@ -54,10 +54,10 @@ defmodule Coxir.Struct.Member do
             member =
               member
               |> Map.merge(%{
-                id: {guild, member.user.id},
-                user_id: member.user.id
+                id: {guild, user},
+                user_id: user
               })
-              |> Map.update(:roles, [], &(Role.get(&1, guild)))
+              |> Map.update(:roles, [], &Role.get(&1, guild))
 
             update(member)
             pretty(member)

--- a/lib/coxir/struct/member.ex
+++ b/lib/coxir/struct/member.ex
@@ -54,7 +54,7 @@ defmodule Coxir.Struct.Member do
             member =
               member
               |> Map.merge(%{
-                id: {member.guild_id, member.user.id},
+                id: {guild, member.user.id},
                 user_id: member.user.id
               })
 

--- a/lib/coxir/struct/role.ex
+++ b/lib/coxir/struct/role.ex
@@ -36,11 +36,17 @@ defmodule Coxir.Struct.Role do
                 error
 
               roles ->
-                role = roles
-                |> Enum.filter(fn role -> role.id == req_role end)
+                roles = roles
+                |> Enum.filter(fn role -> (role.id in req_role) end)
 
-                update(role)
-                pretty(role)
+                for role <- roles do
+                  role
+                  |> Map.put(:guild_id, guild)
+                  |> update()
+                  
+                  pretty(role)
+                end
+
             end
 
           _other ->

--- a/lib/coxir/struct/struct.ex
+++ b/lib/coxir/struct/struct.ex
@@ -4,17 +4,21 @@ defmodule Coxir.Struct do
   defmacro __using__(_opts) do
     quote location: :keep do
       alias Coxir.API
+      alias Coxir.Cache.{ETS, TTL}
+
+      @cache if Application.get_env(:coxir, :ttl), do: TTL, else: ETS
 
       @table __MODULE__
-      |> Module.split
-      |> List.last
-      |> String.downcase
-      |> String.to_atom
+             |> Module.split()
+             |> List.last()
+             |> String.downcase()
+             |> String.to_atom()
 
       defp put(map, key, value) do
         case map do
           %{error: _error} ->
             map
+
           _object ->
             Map.put(map, key, value)
         end
@@ -24,20 +28,25 @@ defmodule Coxir.Struct do
         map
         |> Map.get(key)
         |> case do
-          nil -> nil
+          nil ->
+            nil
+
           list when is_list(list) ->
             Enum.map(list, function)
+
           value ->
             function.(value)
         end
         |> case do
           nil ->
             map
+
           value ->
-            new = key
-            |> Atom.to_string
-            |> String.replace_trailing("_id", "")
-            |> String.to_atom
+            new =
+              key
+              |> Atom.to_string()
+              |> String.replace_trailing("_id", "")
+              |> String.to_atom()
 
             Map.put(map, new, value)
         end
@@ -49,9 +58,10 @@ defmodule Coxir.Struct do
       Returns an object if found
       and `nil` otherwise.
       """
-      @spec get(String.t) :: map | nil
+      @spec get(String.t()) :: map | nil
 
       def get(%{id: id}), do: get(id)
+
       def get(id) do
         fetch(id)
         |> case do
@@ -70,27 +80,22 @@ defmodule Coxir.Struct do
       def select(pattern \\ %{}) do
         :ets.tab2list(@table)
         |> Enum.map(&decode/1)
-        |> Enum.filter(
-          fn struct ->
-            pattern
-            |> Map.to_list
-            |> Enum.filter(
-              fn {key, value} ->
-                struct
-                |> Map.get(key)
-                != value
-              end
-            )
-            |> length
-            == 0
-          end
-        )
+        |> Enum.filter(fn struct ->
+          pattern
+          |> Map.to_list()
+          |> Enum.filter(fn {key, value} ->
+            struct
+            |> Map.get(key) != value
+          end)
+          |> length == 0
+        end)
       end
 
       @doc false
       def remove(%{id: id}), do: remove(id)
+
       def remove(id) do
-        :ets.delete @table, {:id, id}
+        @cache.delete(@table, {:id, id})
       end
 
       @doc false
@@ -98,50 +103,91 @@ defmodule Coxir.Struct do
 
       @doc false
       def update(data) do
-        data = data
-        |> fetch
-        |> case do
-          nil ->
-            data
-          struct ->
-            Map.merge(struct, data)
-        end
+        data =
+          data
+          |> fetch
+          |> case do
+            nil ->
+              data
 
-        :ets.insert @table, encode(data)
+            struct ->
+              Map.merge(struct, data)
+          end
+
+        @cache.insert(@table, encode(data))
       end
 
       defp fetch(%{id: id}), do: fetch(id)
+
       defp fetch(id) do
-        case :ets.lookup(@table, {:id, id}) do
+        @cache.get(@table, {:id, id})
+        |> case do
           [entry] ->
             decode(entry)
-          [] -> nil
+
+          [] ->
+            nil
         end
       end
 
       defp encode(data) do
         data
-        |> Map.to_list
+        |> Map.to_list()
         |> List.insert_at(0, {:id, data.id})
-        |> List.to_tuple
+        |> List.to_tuple()
       end
 
       defp decode(data) do
         data
-        |> Tuple.to_list
-        |> Map.new
+        |> Tuple.to_list()
+        |> Map.new()
       end
 
-      defoverridable [get: 1]
-      defoverridable [pretty: 1]
+      defoverridable get: 1
+      defoverridable pretty: 1
     end
   end
 
   @tables [:user, :guild, :role, :member, :channel, :message]
 
+  defp create_TTL_table(name) do
+    name = "#{name}s" |> String.to_atom()
+
+    %{
+      id: name,
+      start:
+        {SimpleTTL, :start_link,
+         [
+           name,
+           Application.get_env(:coxir, :global_ttl) || :timer.minutes(10),
+           Application.get_env(:coxir, :check_interval) || :timer.minutes(1),
+           [:set, :public, :named_table]
+         ]}
+    }
+  end
+
   def create_tables do
-    for table <- @tables do
-      :ets.new table, [:set, :public, :named_table]
+    if Application.get_env(:coxir, :ttl) do
+      children =
+        for table <- @tables do
+          create_TTL_table(table)
+        end
+
+      options = [
+        strategy: :one_for_one,
+        name:
+          __MODULE__
+          |> Module.split()
+          |> List.last()
+          |> String.downcase()
+          |> String.to_atom()
+      ]
+
+      Supervisor.start_link(children, options)
+    else
+      for table <- @tables do
+        :ets.new(table, [:set, :public, :named_table])
+      end
     end
   end
 end

--- a/lib/coxir/struct/user.ex
+++ b/lib/coxir/struct/user.ex
@@ -21,6 +21,12 @@ defmodule Coxir.Struct.User do
     |> put(:avatar_url, get_avatar(struct))
   end
 
+  @doc """
+  Fetches either the bot user or a cached user object.
+  If not found, it will get requested through the API.
+
+  Returns an object if found and `nil` otherwise.
+  """
   def get(user \\ :local)
   def get(%{id: id}),
     do: get(id)
@@ -34,8 +40,10 @@ defmodule Coxir.Struct.User do
     super(user)
     |> case do
       nil ->
-        API.request(:get, "users/#{user}")
-        |> pretty
+        user = API.request(:get, "users/#{user}")
+
+        update(user)
+        pretty(user)
       user -> user
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,8 @@ defmodule Coxir.Mixfile do
       {:websockex, "~> 0.4.1"},
       {:httpoison, "~> 0.13.0"},
       {:gen_stage, "~> 0.14.0"},
-      {:ex_doc, "~> 0.18.1", only: :dev}
+      {:ex_doc, "~> 0.18.1", only: :dev},
+      {:simple_ttl, github: "awlexus/simplettl"}
     ]
   end
 


### PR DESCRIPTION
As a result of a whole week working on reducing this library's memory usage, a side feature popped into my mind: TTL based Object caching.

This PR adds two functionalities:
- Setting a global TTL to the ETS tables.
- Ability to API request objects if not found in ETS.

For this, a friend and I created [this module](https://github.com/Awlexus/SimpleTTL) which allows the use of TTL on top of ETS tables.

# Users will be able to choose which type of caching they want.
Users will be able to state whether they want TTL or not by simply adding this setting in the config file: 
```elixir
ttl: true
```
If TTL is selected, they will have to state the global TTL (for how long will objects be stored) and how often should we check if they were expired or not.
```elixir
global_ttl: :timer.minutes(10),
check_interval: :timer.minutes(1)
```
## Everytime you access an object, it's TTL will get updated, this way, in a long term, the bot should only cache those objects that it will really use.
With this we earn a huge memory boost by lowering the memory used by ETS objects.

A config example file would look like this:
```elixir
use Mix.Config

config :coxir,
ttl: true,
global_ttl: :timer.minutes(1),
check_interval: :timer.minutes(1),
token: "MjQ3MzEaw42g0Naw4Tcy.sometoken"
```

### For the whole "memory boost" pack you will want as well to apply #25 to your coxir lib.