### PR TITLE
Remove some warnings

### DIFF
--- a/lib/coxir.ex
+++ b/lib/coxir.ex
@@ -20,6 +20,10 @@ defmodule Coxir do
   alias Coxir.{API, Struct}
   alias Coxir.{Voice, Stage, Gateway}
 
+  def init(args) do
+    {:ok, args}
+  end
+
   @doc false
   def start(_type, _args) do
     children = [

--- a/lib/coxir/gateway.ex
+++ b/lib/coxir/gateway.ex
@@ -9,6 +9,10 @@ defmodule Coxir.Gateway do
   alias Coxir.API
   alias Coxir.Gateway.Worker
 
+  def init(args) do
+    {:ok, args}
+  end
+
   @doc false
   def start_link do
     token = Coxir.token()

--- a/lib/coxir/stage.ex
+++ b/lib/coxir/stage.ex
@@ -7,6 +7,10 @@ defmodule Coxir.Stage do
 
   @limit System.schedulers_online()
 
+  def init(args) do
+    {:ok, args}
+  end
+
   def start_link do
     children = [
       worker(Producer, [])

--- a/lib/coxir/voice.ex
+++ b/lib/coxir/voice.ex
@@ -11,6 +11,10 @@ defmodule Coxir.Voice do
   alias Coxir.Struct.{User, Guild}
   alias Coxir.Voice.{Server, Audio}
 
+  def init(args) do
+    {:ok, args}
+  end
+
   @doc false
   def start_link do
     children = []

--- a/lib/coxir/voice/audio.ex
+++ b/lib/coxir/voice/audio.ex
@@ -18,11 +18,11 @@ defmodule Coxir.Voice.Audio do
   #}
   def start_link(state) do
     state = state
-    |> Map.merge %{
+    |> Map.merge(%{
       player: nil,
       sequence: 0,
       timestamp: 0
-    }
+    })
     GenServer.start_link __MODULE__, state
   end
 
@@ -33,11 +33,11 @@ defmodule Coxir.Voice.Audio do
 
   def play(pid, term) do
     pid
-    |> GenServer.call {:play, term}
+    |> GenServer.call({:play, term})
   end
   def stop(pid) do
     pid
-    |> GenServer.call :stop
+    |> GenServer.call(:stop)
   end
 
   def handle_call({:play, term}, _from, state) do
@@ -49,9 +49,9 @@ defmodule Coxir.Voice.Audio do
         Task.start_link(
           fn ->
             state = state
-            |> Map.merge %{
+            |> Map.merge(%{
               audio: audio
-            }
+            })
             do_player(term, state)
           end
         )

--- a/lib/coxir/voice/gateway.ex
+++ b/lib/coxir/voice/gateway.ex
@@ -106,12 +106,12 @@ defmodule Coxir.Voice.Gateway do
     )
 
     state = state
-    |> Map.merge %{
+    |> Map.merge(%{
       udp: udp,
       ip: remote,
       port: data.port,
       ssrc: data.ssrc
-    }
+    })
 
     data = %{
       protocol: "udp",
@@ -131,12 +131,12 @@ defmodule Coxir.Voice.Gateway do
     |> Map.merge(data)
 
     data = data
-    |> Map.merge %{
+    |> Map.merge(%{
       udp: state.udp,
       ssrc: state.ssrc,
       port: state.port,
       ip: state.ip
-    }
+    })
 
     state.handler
     |> send({:update, data})

--- a/lib/coxir/voice/handler.ex
+++ b/lib/coxir/voice/handler.ex
@@ -6,6 +6,10 @@ defmodule Coxir.Voice.Handler do
   alias Coxir.Voice
   alias Coxir.Voice.{Server, Gateway, Audio}
 
+  def init(args) do
+    {:ok, args}
+  end
+
   #{
   #  :server_id,
   #  :client_id,


### PR DESCRIPTION
This greatly reduces the amount of warning spam whenever compiling coxir.
Before:
```
==> coxir
Compiling 26 files (.ex)
warning: function init/1 required by behaviour Supervisor is not implemented (in module Coxir.Gateway)
  lib/coxir/gateway.ex:1

warning: function init/1 required by behaviour Supervisor is not implemented (in module Coxir)
  lib/coxir.ex:1

warning: function init/1 required by behaviour Supervisor is not implemented (in module Coxir.Stage)
  lib/coxir/stage.ex:1

warning: parentheses are required when piping into a function call. For example:

    foo 1 |> bar 2 |> baz 3

is ambiguous and should be written as

    foo(1) |> bar(2) |> baz(3)

Ambiguous pipe found at:
  lib/coxir/voice/audio.ex:21

warning: parentheses are required when piping into a function call. For example:

    foo 1 |> bar 2 |> baz 3

is ambiguous and should be written as

    foo(1) |> bar(2) |> baz(3)

Ambiguous pipe found at:
  lib/coxir/voice/audio.ex:36

warning: parentheses are required when piping into a function call. For example:

    foo 1 |> bar 2 |> baz 3

is ambiguous and should be written as

    foo(1) |> bar(2) |> baz(3)

Ambiguous pipe found at:
  lib/coxir/voice/audio.ex:40

warning: parentheses are required when piping into a function call. For example:

    foo 1 |> bar 2 |> baz 3

is ambiguous and should be written as

    foo(1) |> bar(2) |> baz(3)

Ambiguous pipe found at:
  lib/coxir/voice/audio.ex:52

warning: parentheses are required when piping into a function call. For example:

    foo 1 |> bar 2 |> baz 3

is ambiguous and should be written as

    foo(1) |> bar(2) |> baz(3)

Ambiguous pipe found at:
  lib/coxir/voice/gateway.ex:109

warning: parentheses are required when piping into a function call. For example:

    foo 1 |> bar 2 |> baz 3

is ambiguous and should be written as

    foo(1) |> bar(2) |> baz(3)

Ambiguous pipe found at:
  lib/coxir/voice/gateway.ex:134

warning: function init/1 required by behaviour Supervisor is not implemented (in module Coxir.Voice)
  lib/coxir/voice.ex:1

warning: function init/1 required by behaviour GenServer is not implemented (in module Coxir.Voice.Handler).

We will inject a default implementation for now:

    def init(args) do
      {:ok, args}
    end

You can copy the implementation above or define your own that converts the arguments given to GenServer.start_link/3 to the server state.

  lib/coxir/voice/handler.ex:1

Generated coxir app
```
After:
```
==> coxir
Compiling 26 files (.ex)
Generated coxir app
```