### PR TITLE
Optionally add member count to Coxir.Struct.Invite.get/2

### DIFF
--- a/lib/coxir/struct/invite.ex
+++ b/lib/coxir/struct/invite.ex
@@ -17,9 +17,18 @@ defmodule Coxir.Struct.Invite do
 
   Returns an invite object upon success
   or a map containing error information.
+
+  Accepts an optional parameter `with_counts`
+  in which the invite struct will contain two
+  extra keys, approximate_member_count, the
+  number of members in the server, and
+  approximate_presence_count which is the number
+  of users in the server who are currently online.
   """
-  def get(code) do
-    API.request(:get, "invites/#{code}")
+  @spec get(invite, boolean()) :: map
+
+  def get(code, with_counts \\ false) do
+    API.request(:get, "invites/#{code}?with_counts=#{with_counts}")
   end
 
   @doc """

--- a/lib/coxir/struct/invite.ex
+++ b/lib/coxir/struct/invite.ex
@@ -18,19 +18,11 @@ defmodule Coxir.Struct.Invite do
   Returns an invite object upon success
   or a map containing error information.
 
-  Accepts an optional argument `with_counts?`
-  in which the invite struct will contain two
-  extra keys, approximate_member_count, the
-  number of members in the server, and
-  approximate_presence_count which is the number
-  of users in the server who are currently online.
+  Refer to [this](https://discordapp.com/developers/docs/resources/invite#get-invite)
+  for more information.
   """
-  @spec get(invite, boolean()) :: map
-
   def get(code, with_counts? \\ false) do
-    parameters = [with_counts: with_counts?]
-
-    API.request(:get, "invites/#{code}", "", params: parameters)
+    API.request(:get, "invites/#{code}", "", params: [with_counts: with_counts?])
   end
 
   @doc """

--- a/lib/coxir/struct/invite.ex
+++ b/lib/coxir/struct/invite.ex
@@ -18,7 +18,7 @@ defmodule Coxir.Struct.Invite do
   Returns an invite object upon success
   or a map containing error information.
 
-  Accepts an optional parameter `with_counts`
+  Accepts an optional argument `with_counts`
   in which the invite struct will contain two
   extra keys, approximate_member_count, the
   number of members in the server, and

--- a/lib/coxir/struct/invite.ex
+++ b/lib/coxir/struct/invite.ex
@@ -18,7 +18,7 @@ defmodule Coxir.Struct.Invite do
   Returns an invite object upon success
   or a map containing error information.
 
-  Accepts an optional argument `with_counts`
+  Accepts an optional argument `with_counts?`
   in which the invite struct will contain two
   extra keys, approximate_member_count, the
   number of members in the server, and
@@ -27,8 +27,10 @@ defmodule Coxir.Struct.Invite do
   """
   @spec get(invite, boolean()) :: map
 
-  def get(code, with_counts \\ false) do
-    API.request(:get, "invites/#{code}?with_counts=#{with_counts}")
+  def get(code, with_counts? \\ false) do
+    parameters = [with_counts: with_counts?]
+
+    API.request(:get, "invites/#{code}", "", params: parameters)
   end
 
   @doc """


### PR DESCRIPTION
This PR adds the `with_counts?` parameter onto the end of the request to the Discord API.

This allows member counts of a guild to be found using the invite ID, as demonstrated in this image:
![screen-835420388](https://user-images.githubusercontent.com/20439493/46438699-704cdb00-c756-11e8-80f0-cf07bae1c426.png)

The argument is documented and I have added the missing type-spec to the function.