### PR TITLE
Replaced deprecated time units

### DIFF
--- a/lib/coxir/api/api.ex
+++ b/lib/coxir/api/api.ex
@@ -230,7 +230,7 @@ defmodule Coxir.API do
 
   defp current_time do
     DateTime.utc_now
-    |> DateTime.to_unix(:milliseconds)
+    |> DateTime.to_unix(:millisecond)
   end
 
   defp date_header(header) do

--- a/lib/coxir/struct/user.ex
+++ b/lib/coxir/struct/user.ex
@@ -274,7 +274,7 @@ defmodule Coxir.Struct.User do
     "https://cdn.discordapp.com/avatars/#{id}/#{avatar}.#{extension}"
   end
   def get_avatar(_other), do: nil
-  
+
   @doc """
   Computes the date a user made their account.
 
@@ -294,6 +294,6 @@ defmodule Coxir.Struct.User do
 
     (user >>> 22)
     |> Kernel.+(1_420_070_400_000)
-    |> DateTime.from_unix!(:milliseconds)
+    |> DateTime.from_unix!(:millisecond)
   end
 end


### PR DESCRIPTION
Much changes, such wow.

(addressing this warning)
```elixir
warning: deprecated time unit: :milliseconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer

  (elixir) lib/calendar/datetime.ex:539: DateTime.to_unix/2
  (coxir) lib/coxir/api/api.ex:189: Coxir.API.reset/1
  (coxir) lib/coxir/api/api.ex:130: Coxir.API.route_limit/1
  (coxir) lib/coxir/api/api.ex:30: Coxir.API.request/5
```

[(cute pupper for bonus points)](https://i.imgur.com/cWQUzU1.gif)